### PR TITLE
Add ability to use Access-Control-Allow-Origin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+before_script:
+  - npm install -g gulp
+script:
+  - gulp lint
+  - gulp test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mock Yeah
+# Mock Yeah [![Build Status](https://travis-ci.org/ryanricard/mock-yeah.svg)](https://travis-ci.org/ryanricard/mock-yeah)
 
 __"An invaluable service mocking platform built on Express."__
 

--- a/config.js
+++ b/config.js
@@ -16,7 +16,8 @@ config.file({
 })
 .defaults({
   port: 4001,
-  fixturesDir: './fixtures'
+  fixturesDir: './fixtures',
+  accessControlAllowOrigin: false
 });
 
 module.exports = config;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,11 @@ const app = require('./server').app;
 
 app.config = require('./config');
 
+if (app.config.get('accessControlAllowOrigin')) {
+  const accessControlAllowOrigin = require('./server/middleware').accessControlAllowOrigin;
+  app.use(accessControlAllowOrigin);
+}
+
 const httpServer = app.listen(app.config.get('port'), function listen() {
   const host = this.address().address;
   const port = this.address().port;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-yeah",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "An invaluable service mocking platform built on Express.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-yeah",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "An invaluable service mocking platform built on Express.",
   "main": "index.js",
   "scripts": {

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.accessControlAllowOrigin = function allowCrossDomain(req, res, next) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  next();
+};


### PR DESCRIPTION
Ran into issues when running mock-yeah locally that didn't allow for the use of
provided fixture data. This was an issue we've run into before, and we solved it
via middleware, let me know if you think there is a better way of doing this.

I added a config value `accessControlAllowOrigin`, that is set to `false` by default.
Setting this to true will allow the app to use the Access-Control-Allow-Origin middleware.
This should allow users to run mock-yeah locally on projects that have configurations
that would cause this error.
