### PR TITLE
feat: expect with custom functions

### DIFF
--- a/app/lib/Expectation.js
+++ b/app/lib/Expectation.js
@@ -31,7 +31,7 @@ const assertion = function assertion(value, actualValue, message) {
       assert(result, message);
     }
   } catch (err) {
-    throw new Error(message);
+    assert(false, message);
   }
 };
 
@@ -125,13 +125,13 @@ Expectation.prototype.api = function api() {
         if (typeof value === 'function') {
           const message = `${
             internal.prefix
-          } Expected header value ${name}:${actualValue} to match expected for request`;
+          } Header "${name}: ${actualValue}" did not match expectation callback`;
           assertion(value, actualValue, message);
         } else {
           assert.equal(
             actualValue,
             value,
-            `${internal.prefix} Expected header value ${name}:${value}, but it was ${actualValue}`
+            `${internal.prefix} Header "${name}: ${value}" expected, but got "${actualValue}"`
           );
         }
       });
@@ -139,11 +139,18 @@ Expectation.prototype.api = function api() {
     },
     params: function params(value) {
       internal.handlers.push(req => {
-        const message = `${internal.prefix} Expected params did not match expected for request`;
         if (typeof value === 'function') {
-          assertion(value, req.query, message);
+          assertion(
+            value,
+            req.query,
+            `${internal.prefix} Params did not match expectation callback`
+          );
         } else {
-          assert.deepStrictEqual(req.query, value, message);
+          assert.deepStrictEqual(
+            req.query,
+            value,
+            `${internal.prefix} Params did not match expected`
+          );
         }
       });
       return this;
@@ -151,11 +158,18 @@ Expectation.prototype.api = function api() {
     body: function body(value) {
       internal.handlers.push(req => {
         internal.handlers.push(req => {
-          const message = `${internal.prefix} Expected body to match expected for request`;
           if (typeof value === 'function') {
-            assertion(value, req.body, message);
+            assertion(
+              value,
+              req.body,
+              `${internal.prefix} Body did not match expectation callback`
+            );
           } else {
-            assert.deepStrictEqual(req.body, value, message);
+            assert.deepStrictEqual(
+              req.body,
+              value,
+              `${internal.prefix} Body did not match expected`
+            );
           }
         });
       });

--- a/test/integration/RouteExpectationTest.js
+++ b/test/integration/RouteExpectationTest.js
@@ -262,7 +262,7 @@ describe('Route expectation', () => {
         },
         cb => request.get('/foo').end(cb),
         cb => {
-          expect(expectation.verify).to.throw('Expected params did not match expected for request');
+          expect(expectation.verify).to.throw('Params did not match expected');
           cb();
         }
       ],
@@ -289,7 +289,7 @@ describe('Route expectation', () => {
         },
         cb => request.get('/foo').end(cb),
         cb => {
-          expect(expectation.verify).to.throw('Expected params did not match expected for request');
+          expect(expectation.verify).to.throw('Params did not match expectation callback');
           cb();
         }
       ],
@@ -322,7 +322,7 @@ describe('Route expectation', () => {
             .send({ some: 'value' })
             .end(cb),
         cb => {
-          expect(expectation.verify).to.throw('Expected body to match expected for request');
+          expect(expectation.verify).to.throw('Body did not match expected');
           cb();
         }
       ],
@@ -357,7 +357,7 @@ describe('Route expectation', () => {
             .send({ some: 'value' })
             .end(cb),
         cb => {
-          expect(expectation.verify).to.throw('Expected body to match expected for request');
+          expect(expectation.verify).to.throw('Body did not match expectation callback');
           cb();
         }
       ],
@@ -389,7 +389,7 @@ describe('Route expectation', () => {
             .end(cb),
         cb => {
           expect(expectation.verify).to.throw(
-            'Expected header value host:example.com, but it was unknown.com'
+            'Header "host: example.com" expected, but got "unknown.com"'
           );
           cb();
         }
@@ -422,7 +422,7 @@ describe('Route expectation', () => {
             .end(cb),
         cb => {
           expect(expectation.verify).to.throw(
-            'Expected header value host:unknown.com to match expected for request'
+            'Header "host: unknown.com" did not match expectation callback'
           );
           cb();
         }


### PR DESCRIPTION
Adds support for `expect` with custom functions to assert on behavior for `.params`, `.body`, and `.header`. In custom functions, you can either throw an exception or not, or if you return a value then the expectation will pass based on the truthiness of the return value.

I will work to add documentation after I get approval for this change.