### PR TITLE
chore: test on precommit/push hook, test script lints

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,9 +2,13 @@
 plugins: ["node"] 
 extends: ["airbnb/base", "prettier", "plugin:node/recommended"]
 
+parserOptions:
+  ecmaVersion: 2015
+
 env:
   node: true
   mocha: true
+  es6: true
 
 rules:
   strict: [0, safe]

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ branches:
     - master
 cache: yarn
 script:
-  - yarn lint
   - yarn test

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "A powerful service mocking, recording, and playback utility.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/**/*Test.js",
-    "test:watch": "npm test -- --watch",
+    "test": "yarn lint && yarn test:unit",
+    "test:watch": "yarn test:unit --watch",
+    "test:unit": "mocha test/**/*Test.js",
     "lint": "gulp lint",
-    "lint:watch": "gulp lint:watch"
+    "lint:watch": "gulp lint:watch",
+    "precommit": "yarn test",
+    "prepush": "yarn test"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",
   "author": "Ryan Ricard",
@@ -67,6 +70,7 @@
     "gulp-eslint": "^4.0.2",
     "gulp-mocha": "^2.2.0",
     "gulp-util": "^3.0.7",
+    "husky": "^0.14.3",
     "mocha": "^3.1.2",
     "rimraf": "^2.5.2",
     "supertest": "^1.1.0"

--- a/tasks/path.js
+++ b/tasks/path.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  scripts: ['!node_modules/**', './**/*.js'],
+  scripts: ['!**/node_modules/**', '!./docs/_book/**', './**/*.js'],
   tests: ['./test/**/*Test.js']
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,6 +354,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+ci-info@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
@@ -1552,6 +1556,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -1656,6 +1668,12 @@ is-builtin-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
+
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -2347,6 +2365,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.1:
   version "2.1.1"
@@ -3186,6 +3208,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This adds `husky` to enable pre-commit and pre-push hooks to run lint and test. It also updates `yarn test` to run both lint and test per Node CI conventions. You can run tests alone with `yarn test:unit`. I'm open to removing one or the other. In a follow up PR, we can move to `lint-staged` or something like it. This also adds some more exclusions to the linting, and updates some ESLint settings that might help it parse ES2015+.
