### PR TITLE
feat: mock response data via function or promise

### DIFF
--- a/app/lib/Expectation.js
+++ b/app/lib/Expectation.js
@@ -18,7 +18,7 @@ function Expectation(route) {
 Expectation.prototype.middleware = function middleware(req, res, next) {
   this.called += 1;
   this.handlers.forEach(handler => {
-    this.assertions.push(handler.bind(this, req));
+    this.assertions.push(handler.bind(this, req, res, next));
   });
   req.callCount = this.called;
   next();

--- a/app/lib/routeHandler.js
+++ b/app/lib/routeHandler.js
@@ -35,8 +35,8 @@ const handleFunction = (req, res, next, data) => {
 
   try {
     const result = data(req);
-    if (handlePromise(res, next, data)) return true;
-    res.send(data(req));
+    if (handlePromise(res, next, result)) return true;
+    res.send(result);
   } catch (err) {
     next(err);
   }

--- a/app/lib/routeHandler.js
+++ b/app/lib/routeHandler.js
@@ -4,6 +4,63 @@ const fs = require('fs');
 const path = require('path');
 const expandPath = require('../../lib/expandPath');
 
+/**
+ *
+ * @param {*} res
+ * @param {*} next
+ * @param {*} promise
+ * @returns {bool} Whether or not the argument was a promise and was handled.
+ */
+const handlePromise = (res, next, promise) => {
+  if (!(promise instanceof Promise)) return false;
+
+  promise
+    .then(result => {
+      res.send(result);
+    })
+    .catch(err => next(err));
+
+  return true;
+};
+
+/**
+ *
+ * @param {*} res
+ * @param {*} next
+ * @param {*} promise
+ * @returns {bool} Whether or not the argument was a function and was handled.
+ */
+const handleFunction = (req, res, next, data) => {
+  if (typeof data !== 'function') return false;
+
+  try {
+    const result = data(req);
+    if (handlePromise(res, next, data)) return true;
+    res.send(data(req));
+  } catch (err) {
+    next(err);
+  }
+
+  return true;
+};
+
+/**
+ * Handle data as potentially function or promise.
+ *
+ * @param {*} req
+ * @param {*} res
+ * @param {*} next
+ * @param {*} data Either raw data supported but `res.send`,
+ *  or a promise resolving such data, or a function returning such data or such a promise.
+ */
+const handleData = (req, res, next, data) => {
+  if (handleFunction(req, res, next, data)) return;
+  if (handlePromise(res, next, data)) return;
+
+  // Else it's raw data, so send it directly.
+  res.send(data);
+};
+
 /* eslint-disable prefer-template */
 function validateResponse(response) {
   let payloadKeysPresent = 0;
@@ -55,7 +112,7 @@ module.exports = function handler(route) {
 
   validateResponse(response);
 
-  return (req, res) => {
+  return (req, res, next) => {
     const start = new Date().getTime();
     let send;
 
@@ -89,6 +146,8 @@ module.exports = function handler(route) {
     // set response headers, if received
     if (response.headers) res.set(response.headers);
 
+    const handleDataBound = handleData.bind(null, req, res, next);
+
     if (response.filePath) {
       // if filePath, send file
       const filePath = expandPath(response.filePath);
@@ -111,18 +170,18 @@ module.exports = function handler(route) {
     } else if (response.html) {
       // if html, set Content-Type to application/html and send
       res.type(response.type || 'html');
-      send = res.send.bind(res, response.html);
+      send = handleDataBound.bind(null, response.html);
     } else if (response.json) {
       // if json, set Content-Type to application/json and send
       res.type(response.type || 'json');
-      send = res.send.bind(res, response.json);
+      send = handleDataBound.bind(null, response.json);
     } else if (response.text) {
       // if text, set Content-Type to text/plain and send
       res.type(response.type || 'text');
-      send = res.send.bind(res, response.text);
+      send = handleDataBound.bind(null, response.text);
     } else if (response.raw) {
       // if raw, don't set Content-Type
-      send = res.send.bind(res, response.raw);
+      send = handleDataBound.bind(null, response.raw);
     } else {
       // else send empty response
       res.type(response.type || 'text');

--- a/examples/respond-with-json-function-returning-promise.js
+++ b/examples/respond-with-json-function-returning-promise.js
@@ -1,0 +1,12 @@
+const http = require('http');
+const log = require('./log');
+const mockyeah = require('./mockyeah');
+
+mockyeah.get('/', {
+  json: req => Promise.resolve({ hey: 'it worked!', query: req.query })
+});
+
+http.get('http://localhost:4001', res => {
+  log(res);
+  mockyeah.close();
+});

--- a/examples/respond-with-json-function.js
+++ b/examples/respond-with-json-function.js
@@ -1,0 +1,10 @@
+const http = require('http');
+const log = require('./log');
+const mockyeah = require('./mockyeah');
+
+mockyeah.get('/', { json: req => ({ hey: 'it worked!', query: req.query }) });
+
+http.get('http://localhost:4001?ok=yes', res => {
+  log(res);
+  mockyeah.close();
+});

--- a/examples/respond-with-json-promise.js
+++ b/examples/respond-with-json-promise.js
@@ -1,0 +1,12 @@
+const http = require('http');
+const log = require('./log');
+const mockyeah = require('./mockyeah');
+
+mockyeah.get('/', {
+  json: Promise.resolve({ hey: 'it worked!' })
+});
+
+http.get('http://localhost:4001?ok=yes', res => {
+  log(res);
+  mockyeah.close();
+});

--- a/test/integration/ResponseDynamicTest.js
+++ b/test/integration/ResponseDynamicTest.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { forEach } = require('lodash');
+const TestHelper = require('../TestHelper');
+
+const { mockyeah, request } = TestHelper;
+
+const sets = {
+  html: {
+    data: '<p>Hello</p>',
+    body: /Hello/,
+    type: /text\/html/
+  },
+  json: {
+    data: { foo: 'bar' },
+    body: '{"foo":"bar"}',
+    type: /application\/json/
+  },
+  text: {
+    data: 'Hello',
+    body: 'Hello',
+    type: /text\/plain/
+  }
+};
+
+describe('Response Dynamic', () => {
+  forEach(sets, (set, label) => {
+    describe(label, () => {
+      it('should respond with content and type for function', done => {
+        mockyeah.get('/service/exists', { [label]: () => set.data });
+
+        request
+          .get('/service/exists')
+          .expect('Content-Type', set.type)
+          .expect(200, set.body, done);
+      });
+
+      it('should allow Content-Type override for function', done => {
+        mockyeah.get('/service/exists', { [label]: () => set.data, type: 'text' });
+
+        request
+          .get('/service/exists')
+          .expect('Content-Type', /text\/plain/)
+          .expect(200, set.body, done);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Based on https://github.com/mockyeah/mockyeah/issues/5#issuecomment-369390081, allows defining mock response data (e.g., `json`, `html`, or `text`) as a function that receives the `req` object and should return the response body data, or as a promise that resolves the data, or as a function that receives `req` and returns such a promise. This allows custom logic to change the response data based on each request.

See the added tests and examples for more details, or ask any questions.

I'll add documentation for this once we have the structure of the GitBook in place (#70).
