### PR TITLE
feat: match headers, and with regex & functions

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -39,23 +39,26 @@ function isRouteForRequest(route, req) {
 
   if (!matchesParams) return false;
 
-  if (route.body) {
-    // TODO: See what `req.body` looks like with different request content types.
-    const matchesBody = _.isMatch(req.body, route.body);
-    return matchesBody;
-  }
+  // TODO: See what `req.body` looks like with different request content types.
+  if (route.body && !_.isMatch(req.body, route.body)) return false;
 
-  // TODO: Later add features to match other things, like headers, or with functions, regex, etc.
+  if (route.headers && !_.isMatch(req.headers, route.headers)) return false;
+
+  // TODO: Later add features to match other things, like cookies, or with functions, regex, etc.
 
   return true;
 }
 
+/**
+ * This is used for replacing routes, so we need exact matches.
+ */
 function isRouteMatch(route1, route2) {
   return (
     route1.pathname === route2.pathname &&
     route1.method === route2.method &&
     _.isEqual(route1.query, route2.query) &&
-    _.isEqual(route1.body, route2.body)
+    _.isEqual(route1.body, route2.body) &&
+    _.isEqual(route1.headers, route2.headers)
   );
 }
 
@@ -118,6 +121,7 @@ RouteResolver.prototype.register = function register(method, path, response) {
     route.pathname = normalizePathname(object.path);
     route.query = object.query || null; // because `url.parse` returns `null`
     route.body = object.body;
+    route.headers = object.headers;
   }
 
   const matchKeys = [];

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "express": "^4.13.3",
     "http-proxy-middleware": "^0.17.4",
     "is-absolute-url": "^2.1.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.5",
     "mkdirp": "^0.5.1",
     "path-to-regexp": "^2.1.0",
     "request": "^2.69.0",

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -286,4 +286,58 @@ describe('Route Patterns', () => {
 
     request.post('/nope').expect(404, done);
   });
+
+  it('should match request headers', done => {
+    mockyeah.post({
+      path: '/foo',
+      headers: {
+        bar: 'yes'
+      }
+    });
+
+    request
+      .post('/foo')
+      .set('bar', 'yes')
+      .expect(200, done);
+  });
+
+  it('should match with partial request headers', done => {
+    mockyeah.post({
+      path: '/foo',
+      headers: {
+        bar: 'yes'
+      }
+    });
+
+    request
+      .post('/foo')
+      .set('bar', 'yes')
+      .set('and', 'this')
+      .expect(200, done);
+  });
+
+  it('should fail to match when different request headers', done => {
+    mockyeah.post({
+      path: '/nope',
+      headers: {
+        bar: 'nope'
+      }
+    });
+
+    request
+      .post('/nope')
+      .set('bar', 'yes')
+      .expect(404, done);
+  });
+
+  it('should fail to match when no request headers', done => {
+    mockyeah.post({
+      path: '/nope',
+      headers: {
+        bar: 'nope'
+      }
+    });
+
+    request.post('/nope').expect(404, done);
+  });
 });

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -165,7 +165,7 @@ describe('Route Patterns', () => {
     request.get('/service/exists').expect(200, done);
   });
 
-  it('should fail when doesnt match query parameters', done => {
+  it('should fail when does not match query parameters', done => {
     mockyeah.get('/foo?bar=yes');
 
     request.get('/foo').expect(404, done);
@@ -188,6 +188,17 @@ describe('Route Patterns', () => {
     request.get('/foo?bar=yes').expect(200, done);
   });
 
+  it('should match single query parameter with object and regex', done => {
+    mockyeah.get({
+      path: '/foo',
+      query: {
+        bar: /e/
+      }
+    });
+
+    request.get('/foo?bar=yes').expect(200, done);
+  });
+
   it('should match multiple query parameters', done => {
     mockyeah.get('/foo?bar=yes&cool=duh');
 
@@ -200,6 +211,18 @@ describe('Route Patterns', () => {
       query: {
         bar: 'yes',
         cool: 'duh'
+      }
+    });
+
+    request.get('/foo?bar=yes&cool=duh').expect(200, done);
+  });
+
+  it('should match multiple query parameters with object and regex', done => {
+    mockyeah.get({
+      path: '/foo',
+      query: {
+        bar: /s/,
+        cool: /d/
       }
     });
 
@@ -238,6 +261,20 @@ describe('Route Patterns', () => {
       .expect(200, done);
   });
 
+  it('should match request body with regex', done => {
+    mockyeah.post({
+      path: '/foo',
+      body: {
+        bar: /es/
+      }
+    });
+
+    request
+      .post('/foo')
+      .send({ bar: 'yes' })
+      .expect(200, done);
+  });
+
   it('should match with partial request body', done => {
     mockyeah.post({
       path: '/foo',
@@ -245,6 +282,30 @@ describe('Route Patterns', () => {
         bar: 'yes',
         nest: {
           deep: 'too'
+        }
+      }
+    });
+
+    request
+      .post('/foo')
+      .send({
+        bar: 'yes',
+        nest: {
+          deep: 'too',
+          also: 'more'
+        },
+        and: 'this'
+      })
+      .expect(200, done);
+  });
+
+  it('should match with partial request body and regex', done => {
+    mockyeah.post({
+      path: '/foo',
+      body: {
+        bar: 'yes',
+        nest: {
+          deep: /oo/
         }
       }
     });
@@ -276,6 +337,20 @@ describe('Route Patterns', () => {
       .expect(404, done);
   });
 
+  it('should fail to match when different request body and regex', done => {
+    mockyeah.post({
+      path: '/nope',
+      body: {
+        bar: /op/
+      }
+    });
+
+    request
+      .post('/nope')
+      .send({ bar: 'yes' })
+      .expect(404, done);
+  });
+
   it('should fail to match when no request body', done => {
     mockyeah.post({
       path: '/nope',
@@ -287,11 +362,36 @@ describe('Route Patterns', () => {
     request.post('/nope').expect(404, done);
   });
 
+  it('should fail to match when no request body', done => {
+    mockyeah.post({
+      path: '/nope',
+      body: {
+        bar: /no/
+      }
+    });
+
+    request.post('/nope').expect(404, done);
+  });
+
   it('should match request headers', done => {
     mockyeah.post({
       path: '/foo',
       headers: {
         bar: 'yes'
+      }
+    });
+
+    request
+      .post('/foo')
+      .set('bar', 'yes')
+      .expect(200, done);
+  });
+
+  it('should match request headers with regex', done => {
+    mockyeah.post({
+      path: '/foo',
+      headers: {
+        bar: /yes/
       }
     });
 
@@ -316,6 +416,21 @@ describe('Route Patterns', () => {
       .expect(200, done);
   });
 
+  it('should match with partial request headers with regex', done => {
+    mockyeah.post({
+      path: '/foo',
+      headers: {
+        bar: /ye/
+      }
+    });
+
+    request
+      .post('/foo')
+      .set('bar', 'yes')
+      .set('and', 'this')
+      .expect(200, done);
+  });
+
   it('should fail to match when different request headers', done => {
     mockyeah.post({
       path: '/nope',
@@ -330,11 +445,36 @@ describe('Route Patterns', () => {
       .expect(404, done);
   });
 
+  it('should fail to match when different request headers with regex', done => {
+    mockyeah.post({
+      path: '/nope',
+      headers: {
+        bar: /nop/
+      }
+    });
+
+    request
+      .post('/nope')
+      .set('bar', 'yes')
+      .expect(404, done);
+  });
+
   it('should fail to match when no request headers', done => {
     mockyeah.post({
       path: '/nope',
       headers: {
         bar: 'nope'
+      }
+    });
+
+    request.post('/nope').expect(404, done);
+  });
+
+  it('should fail to match when no request headers with regex', done => {
+    mockyeah.post({
+      path: '/nope',
+      headers: {
+        bar: /pe/
       }
     });
 

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -275,6 +275,19 @@ describe('Route Patterns', () => {
       .expect(200, done);
   });
 
+  it('should match request body with function', done => {
+    mockyeah.post({
+      path: '/foo',
+      body: {
+        bar: value => value === 'yes'
+      }
+    });
+    request
+      .post('/foo')
+      .send({ bar: 'yes' })
+      .expect(200, done);
+  });
+
   it('should match with partial request body', done => {
     mockyeah.post({
       path: '/foo',
@@ -401,6 +414,20 @@ describe('Route Patterns', () => {
       .expect(200, done);
   });
 
+  it('should match request headers with function', done => {
+    mockyeah.post({
+      path: '/foo',
+      headers: {
+        bar: value => value === 'yes'
+      }
+    });
+
+    request
+      .post('/foo')
+      .set('bar', 'yes')
+      .expect(200, done);
+  });
+
   it('should match with partial request headers', done => {
     mockyeah.post({
       path: '/foo',
@@ -421,6 +448,21 @@ describe('Route Patterns', () => {
       path: '/foo',
       headers: {
         bar: /ye/
+      }
+    });
+
+    request
+      .post('/foo')
+      .set('bar', 'yes')
+      .set('and', 'this')
+      .expect(200, done);
+  });
+
+  it('should match with partial request headers with function', done => {
+    mockyeah.post({
+      path: '/foo',
+      headers: {
+        bar: value => value === 'yes'
       }
     });
 
@@ -459,6 +501,20 @@ describe('Route Patterns', () => {
       .expect(404, done);
   });
 
+  it('should fail to match when different request headers with function', done => {
+    mockyeah.post({
+      path: '/nope',
+      headers: {
+        bar: value => value === 'nope'
+      }
+    });
+
+    request
+      .post('/nope')
+      .set('bar', 'yes')
+      .expect(404, done);
+  });
+
   it('should fail to match when no request headers', done => {
     mockyeah.post({
       path: '/nope',
@@ -475,6 +531,17 @@ describe('Route Patterns', () => {
       path: '/nope',
       headers: {
         bar: /pe/
+      }
+    });
+
+    request.post('/nope').expect(404, done);
+  });
+
+  it('should fail to match when no request headers with function', done => {
+    mockyeah.post({
+      path: '/nope',
+      headers: {
+        bar: value => value === 'yes'
       }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,11 +2088,7 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
This adds feature to match against HTTP headers. Also, it adds support for using regular expressions and functions within object matches, for both existing parameters and body matches, and the new headers matches. The new regex and function matching will allow mocking requests more complexly, which will be particularly handy for something like matching based on a specific cookie using the headers matching feature this adds against the `Cookie` header. In the future, we could add a dedicated API for cookie matching functionality, but the regex and function based matching have other power too that is worthwhile.

Added unit tests for all new functionality. See those for examples.

Once approved and documentation structure is initialized, I will add.

For now, to replace/override/reset a specific mock that uses the function matching feature, identical function references need to be used, rather than equivalent but unique function instances. We may fix this in a future PR.

We had to upgrade Lodash for the regex and function matching features, which depend on `_.isEqualWith` and `_.isMatchWith`, which are only available in their current forms in the latest versions of Lodash.
