### PR TITLE
docs: link to v0.x docs and support publishing both

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -7,8 +7,6 @@
 [![npm](https://img.shields.io/npm/v/mockyeah.svg)](https://www.npmjs.com/package/mockyeah)
 [![Travis](https://img.shields.io/travis/mockyeah/mockyeah.svg)](https://travis-ci.org/mockyeah/mockyeah)
 
-[v0.x docs](https://mockyeah.js.org/archive/0.16)
-
 ## What problem does mockyeah solve?
 
 Helps decouple HTTP integrations throughout development and testing.

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -7,6 +7,8 @@
 [![npm](https://img.shields.io/npm/v/mockyeah.svg)](https://www.npmjs.com/package/mockyeah)
 [![Travis](https://img.shields.io/travis/mockyeah/mockyeah.svg)](https://travis-ci.org/mockyeah/mockyeah)
 
+[v0.x docs](https://mockyeah.js.org/archive/0.16)
+
 ## What problem does mockyeah solve?
 
 Helps decouple HTTP integrations throughout development and testing.

--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -34,3 +34,4 @@
 * [Recipes/Examples](https://github.com/mockyeah/mockyeah/tree/master/examples)
 * [CLI](Service-Snapshot-CLI.md)
 * [Contributing](Contributing.md)
+* [v0.x docs](https://mockyeah.js.org/archive/0.16)

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,9 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "gitbook serve",
-    "build": "gitbook build && cp CNAME _book/CNAME",
-    "docs:publish": "gh-pages -d _book",
-    "docs:publish:archive": "gh-pages -d _book -e"
+    "build": "gitbook build",
+    "docs:publish": "yarn build && git checkout f1d15fb && mkdir -p _book/archive/0.16 && gitbook build . _book/archive/0.16 && cp CNAME _book/CNAME && gh-pages -d _book && git checkout -"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",
   "author": "Ryan Ricard",


### PR DESCRIPTION
Previous archive publish functionality seemed to be clobbered by additional publishes. This corrects the `docs:publish` script to support both. Pending ideas how to do this faster and more cleanly in the future. Also links to `v0.x` docs from the summary sidebar.

Relates to #70.