### PR TITLE
fix: support meta matches with absolute URLs

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -49,9 +49,11 @@ function isRouteForRequest(route, req) {
 
   const routePathnameIsAbsoluteUrl = isAbsoluteUrl(route.pathname.replace(/^\//, ''));
 
-  if (routePathnameIsAbsoluteUrl && pathname === route.pathname) return true;
-
-  if (route.pathname !== '*' && !route.pathRegExp.test(pathname)) return false;
+  if (routePathnameIsAbsoluteUrl) {
+    if (route.pathname !== pathname) return false;
+  } else {
+    if (route.pathname !== '*' && !route.pathRegExp.test(pathname)) return false;
+  }
 
   const matchesParams = _.every(route.query, (value, key) =>
     isEqualWithCustomizer(_.get(req.query, key), value)

--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -50,8 +50,10 @@ function isRouteForRequest(route, req) {
   const routePathnameIsAbsoluteUrl = isAbsoluteUrl(route.pathname.replace(/^\//, ''));
 
   if (routePathnameIsAbsoluteUrl) {
+    // eslint-disable-next-line no-lonely-if
     if (route.pathname !== pathname) return false;
   } else {
+    // eslint-disable-next-line no-lonely-if
     if (route.pathname !== '*' && !route.pathRegExp.test(pathname)) return false;
   }
 

--- a/test/integration/RouteProxyTest.js
+++ b/test/integration/RouteProxyTest.js
@@ -55,4 +55,10 @@ describe('Route proxy', () => {
   it('should support proxying other URLs', done => {
     request.get('/http://localhost:8888/foo?ok=yes').expect(200, done);
   });
+  
+  it('should support proxying other URLs even with other mocks', done => {
+    mockyeah.get('/http://localhost:8888/bar', { text: 'bar' });
+
+    request.get('/http://localhost:8888/foo?ok=yes').expect(200, done);
+  });
 });


### PR DESCRIPTION
This was a bug where mocks for paths that look like absolute URLs (usually for matching with proxy), we were not checking some of the meta matches like `params`, `headers`, `body`, etc.
