### PR TITLE
feat: support path regex for absolute urls

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -51,7 +51,7 @@ function isRouteForRequest(route, req) {
 
   if (routePathnameIsAbsoluteUrl) {
     // eslint-disable-next-line no-lonely-if
-    if (route.pathname !== pathname) return false;
+    if (!route.pathRegExp.test(pathname)) return false;
   } else {
     // eslint-disable-next-line no-lonely-if
     if (route.pathname !== '*' && !route.pathRegExp.test(pathname)) return false;

--- a/test/integration/RouteProxyTest.js
+++ b/test/integration/RouteProxyTest.js
@@ -61,6 +61,21 @@ describe('Route proxy', () => {
     );
   });
 
+  it('should support registering full URLs manually with wildcards', done => {
+    mockyeah.get('/http://localhost:8888/f(.*)', { text: 'bar', status: 500 });
+
+    async.series(
+      [
+        cb =>
+          supertest(proxiedApp)
+            .get('/foo')
+            .expect(200, cb),
+        cb => request.get('/http://localhost:8888/foo?ok=yes').expect(500, 'bar', cb)
+      ],
+      done
+    );
+  });
+
   it('should support registering full URLs manually without leading slash', done => {
     mockyeah.get('http://localhost:8888/foo?ok=yes', { text: 'bar', status: 500 });
 


### PR DESCRIPTION
We were not supporting the Express path syntax like wildcards when matching paths that look like absolute URLs (for the proxy/mock use case).

Example:

```js
  mockyeah.get(
    '/https://api.example.com/foo(.*)',
    {
      fixture: 'foos.json'
    }
  );
```
