### PR TITLE
feat: match any header name casing

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -156,7 +156,7 @@ RouteResolver.prototype.register = function register(method, path, response) {
     route.pathname = normalizePathname(url.pathname);
     route.query = object.query || url.query || null; // because `url.parse` returns `null`
     route.body = object.body;
-    route.headers = object.headers;
+    route.headers = _.mapKeys(object.headers, (value, key) => key.toLowerCase());
   }
 
   const matchKeys = [];

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -424,6 +424,22 @@ describe('Route Patterns', () => {
       .expect(200, done);
   });
 
+  it('should match request header names with any casing', done => {
+    mockyeah.post({
+      path: '/foo',
+      headers: {
+        bar: 'yes',
+        BAZ: 'also'
+      }
+    });
+
+    request
+      .post('/foo')
+      .set('BAR', 'yes')
+      .set('baz', 'also')
+      .expect(200, done);
+  });
+
   it('should match request headers with regex', done => {
     mockyeah.post({
       path: '/foo',

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -411,7 +411,7 @@ describe('Route Patterns', () => {
   });
 
   it('should match request headers', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/foo',
       headers: {
         bar: 'yes'
@@ -419,13 +419,13 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/foo')
+      .get('/foo')
       .set('bar', 'yes')
       .expect(200, done);
   });
 
   it('should match request header names with any casing', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/foo',
       headers: {
         bar: 'yes',
@@ -434,14 +434,14 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/foo')
+      .get('/foo')
       .set('BAR', 'yes')
       .set('baz', 'also')
       .expect(200, done);
   });
 
   it('should match request headers with regex', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/foo',
       headers: {
         bar: /yes/
@@ -449,13 +449,13 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/foo')
+      .get('/foo')
       .set('bar', 'yes')
       .expect(200, done);
   });
 
   it('should match request headers with function', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/foo',
       headers: {
         bar: value => value === 'yes'
@@ -463,13 +463,13 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/foo')
+      .get('/foo')
       .set('bar', 'yes')
       .expect(200, done);
   });
 
   it('should match with partial request headers', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/foo',
       headers: {
         bar: 'yes'
@@ -477,14 +477,14 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/foo')
+      .get('/foo')
       .set('bar', 'yes')
       .set('and', 'this')
       .expect(200, done);
   });
 
   it('should match with partial request headers with regex', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/foo',
       headers: {
         bar: /ye/
@@ -492,14 +492,14 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/foo')
+      .get('/foo')
       .set('bar', 'yes')
       .set('and', 'this')
       .expect(200, done);
   });
 
   it('should match with partial request headers with function', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/foo',
       headers: {
         bar: value => value === 'yes'
@@ -507,14 +507,14 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/foo')
+      .get('/foo')
       .set('bar', 'yes')
       .set('and', 'this')
       .expect(200, done);
   });
 
   it('should fail to match when different request headers', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/nope',
       headers: {
         bar: 'nope'
@@ -522,13 +522,13 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/nope')
+      .get('/nope')
       .set('bar', 'yes')
       .expect(404, done);
   });
 
   it('should fail to match when different request headers with regex', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/nope',
       headers: {
         bar: /nop/
@@ -536,13 +536,13 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/nope')
+      .get('/nope')
       .set('bar', 'yes')
       .expect(404, done);
   });
 
   it('should fail to match when different request headers with function', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/nope',
       headers: {
         bar: value => value === 'nope'
@@ -550,41 +550,41 @@ describe('Route Patterns', () => {
     });
 
     request
-      .post('/nope')
+      .get('/nope')
       .set('bar', 'yes')
       .expect(404, done);
   });
 
   it('should fail to match when no request headers', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/nope',
       headers: {
         bar: 'nope'
       }
     });
 
-    request.post('/nope').expect(404, done);
+    request.get('/nope').expect(404, done);
   });
 
   it('should fail to match when no request headers with regex', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/nope',
       headers: {
         bar: /pe/
       }
     });
 
-    request.post('/nope').expect(404, done);
+    request.get('/nope').expect(404, done);
   });
 
   it('should fail to match when no request headers with function', done => {
-    mockyeah.post({
+    mockyeah.get({
       path: '/nope',
       headers: {
         bar: value => value === 'yes'
       }
     });
 
-    request.post('/nope').expect(404, done);
+    request.get('/nope').expect(404, done);
   });
 });


### PR DESCRIPTION
Fixes #119.

Also refactors some tests for headers to use `get` instead of `post`, since that's simpler.