### PR TITLE
feat: `all` matches method only if passed

### DIFF
--- a/app/lib/RouteManager.js
+++ b/app/lib/RouteManager.js
@@ -19,7 +19,8 @@ module.exports = function RouteManager(app) {
     },
 
     all: function all(_path, response) {
-      return this.register(_path.method || 'all', _path, response);
+      const method = _path.method ? _path.method.toLowerCase() : 'all';
+      return this.register(method, _path, response);
     },
 
     get: function get(_path, response) {

--- a/app/lib/RouteManager.js
+++ b/app/lib/RouteManager.js
@@ -19,7 +19,7 @@ module.exports = function RouteManager(app) {
     },
 
     all: function all(_path, response) {
-      return this.register('all', _path, response);
+      return this.register(_path.method || 'all', _path, response);
     },
 
     get: function get(_path, response) {

--- a/docs/book/API/Mock-API.md
+++ b/docs/book/API/Mock-API.md
@@ -39,7 +39,7 @@ then use the object syntax. All keys but `path` are optional. Its structure is:
     [name: string]: MatchString
   },
   body?: MatchBody,
-  method?: string
+  method?: Method
 }
 ```
 
@@ -52,13 +52,15 @@ type MatchString = string | RegExp | (string) => boolean;
 type MatchBody = {
   [key: string]: MatchBody | MatchString | mixed
 };
+
+type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'all'
 ```
 
 Body matching is currently only supported for JSON payloads.
 
 Objects like `headers` and `body` can be partial, deep object matches - they do not need to match the entire set of headers or the entire body of the request.
 
-If using `.all`, you may use `method` to match only a specific method anyway. This may ease programmatic use, e.g., wiring up mocks from a declarative definition.
+If using `.all`, you may use `method` to match only a specific method anyway. Supports any casing. This may ease programmatic use, e.g., wiring up mocks from a declarative definition.
 
 Examples:
 

--- a/docs/book/API/Mock-API.md
+++ b/docs/book/API/Mock-API.md
@@ -38,7 +38,8 @@ then use the object syntax. All keys but `path` are optional. Its structure is:
   headers?: {
     [name: string]: MatchString
   },
-  body?: MatchBody
+  body?: MatchBody,
+  method?: string
 }
 ```
 
@@ -57,6 +58,8 @@ Body matching is currently only supported for JSON payloads.
 
 Objects like `headers` and `body` can be partial, deep object matches - they do not need to match the entire set of headers or the entire body of the request.
 
+If using `.all`, you may use `method` to match only a specific method anyway. This may ease programmatic use, e.g., wiring up mocks from a declarative definition.
+
 Examples:
 
 ```js
@@ -69,6 +72,16 @@ mockyeah.post(
     body: {
       to: 'friend'
     }
+  },
+  { text: 'hello, friend' }
+);
+```
+
+```js
+mockyeah.all(
+  {
+    path: '/say-hello',
+    method: 'get'
   },
   { text: 'hello, friend' }
 );

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -15,6 +15,15 @@ describe('Route Patterns', () => {
 
       request.post('/').expect(200, done);
     });
+    
+    it('should match method in uppercase if passed as option', done => {
+      mockyeah.all({
+        path: '/',
+        method: 'POST'
+      });
+
+      request.post('/').expect(200, done);
+    });
 
     it('should match only method if passed as option', done => {
       mockyeah.all({

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -6,6 +6,26 @@ const TestHelper = require('../TestHelper');
 const { mockyeah, request } = TestHelper;
 
 describe('Route Patterns', () => {
+  describe('method', () => {
+    it('should match method if passed as option', done => {
+      mockyeah.all({
+        path: '/',
+        method: 'post'
+      });
+
+      request.post('/').expect(200, done);
+    });
+
+    it('should match only method if passed as option', done => {
+      mockyeah.all({
+        path: '/',
+        method: 'get'
+      });
+
+      request.post('/').expect(404, done);
+    });
+  });
+
   describe('trailing slashes', () => {
     it('should match when root mock and request use trailing slash', done => {
       mockyeah.get('//');


### PR DESCRIPTION
This enables calling `mockyeah.all()` while still specifying the method but within the match object, which makes it easier to programmatically wire up mocks from a declarative definition.

In future, we could support a more generically named method like `mockyeah.mock()` or even just `mockyeah()`, where this would be especially handy.