### PR TITLE
feat: support env var MOCKYEAH_ROOT

### DIFF
--- a/lib/relativeRoot.js
+++ b/lib/relativeRoot.js
@@ -3,11 +3,10 @@
 const path = require('path');
 
 const wrappingProjectRoot = path.join(__dirname, '..', '..', '..');
-
-const globalRoot = process.env.MOCKYEAH_ROOT || global.MOCKYEAH_ROOT;
+const relativeRoot = process.env.MOCKYEAH_ROOT || global.MOCKYEAH_ROOT || wrappingProjectRoot;
 
 /**
  * Determine wrapping application root
  *  Needed for searching for .mockyeah configuration file.
  */
-module.exports = path.resolve(globalRoot || wrappingProjectRoot);
+module.exports = path.resolve(relativeRoot);

--- a/lib/relativeRoot.js
+++ b/lib/relativeRoot.js
@@ -2,10 +2,12 @@
 
 const path = require('path');
 
-const wrappingProjectRoot = path.resolve(__dirname, '../../..');
+const wrappingProjectRoot = path.join(__dirname, '..', '..', '..');
+
+const globalRoot = process.env.MOCKYEAH_ROOT || global.MOCKYEAH_ROOT;
 
 /**
  * Determine wrapping application root
  *  Needed for searching for .mockyeah configuration file.
  */
-module.exports = global.MOCKYEAH_ROOT ? global.MOCKYEAH_ROOT : wrappingProjectRoot;
+module.exports = path.resolve(globalRoot || wrappingProjectRoot);


### PR DESCRIPTION
`MOCKYEAH_ROOT` is useful sometimes, especially when developing through a symlink like with `npm link` or `yarn link`. But having to configure it programmatically from external code using `global` is less ideal than supporting it as an environment variable.

This also adds `path.resolve` so that we support paths relative to the current working directory for both the global and the env var.

For now, it could be used like this:
```sh
MOCKYEAH_ROOT=. node index.js
```

I'm not sure if there's a clean way to add tests for this...
