### PR TITLE
fix: log route paths correctly on app startup

### DIFF
--- a/app/lib/RouteManager.js
+++ b/app/lib/RouteManager.js
@@ -14,7 +14,7 @@ module.exports = function RouteManager(app) {
 
   return {
     register: function register(method, _path, response) {
-      app.log(['serve', 'mount', method], _path);
+      app.log(['serve', 'mount', method], _path.path || _path);
       return routeResolver.register(method, _path, response);
     },
 


### PR DESCRIPTION
Routes using the object syntax for matchers were incorrectly stringifying their path on app startup, e.g.,
```
[mockyeah][16:39:30][SERVE][MOUNT][POST] [object Object]
```

This fixes the logger to always print the path of the route properly.