### PR TITLE
chore: npmignore packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 docs
 tasks
+packages
 
 .*
 


### PR DESCRIPTION
Since we still have `mockyeah` core at the root level directory, we should exclude `packages` from the published bundle, which includes the sub-modules via `lerna` in the monorepo.