### PR TITLE
fix: initialize set for recording

### DIFF
--- a/app/proxyRoute.js
+++ b/app/proxyRoute.js
@@ -65,8 +65,6 @@ module.exports = (req, res, next) => {
 
       const latency = now() - startTime;
 
-      app.locals.recordMeta = app.locals.recordMeta || {};
-      app.locals.recordMeta.set = app.locals.recordMeta.set || [];
       app.locals.recordMeta.set.push([
         {
           method: method.toLowerCase(),

--- a/app/recorder.js
+++ b/app/recorder.js
@@ -6,7 +6,8 @@ module.exports = app => (name, options) => {
 
   app.locals.recordMeta = {
     name,
-    options
+    options,
+    set: []
   };
 
   // Store whether we're proxying so we can reset it later.

--- a/app/recorder.js
+++ b/app/recorder.js
@@ -16,8 +16,8 @@ module.exports = app => (name, options = {}) => {
   app.locals.recordMeta = {
     name,
     options,
-    set: [],
-    only
+    only,
+    set: []
   };
 
   // Store whether we're proxying so we can reset it later.


### PR DESCRIPTION
Simple fix, initializes the recording set so we can safely assume it's an array later.