### PR TITLE
fix: default config as empty object for default logic

### DIFF
--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -24,7 +24,7 @@ module.exports = (config = {}) => {
   config.adminHost = config.adminHost || config.host || configDefaults.host;
   config.proxy = (config.proxy || config.record) === true;
 
-  config = Object.assign({}, configDefaults, config || {});
+  config = Object.assign({}, configDefaults, config);
 
   // Expand file system configuration paths relative to configuration root
   config.fixturesDir = expandPath(config.fixturesDir);

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -20,7 +20,7 @@ const configDefaults = {
   adminPort: 4777
 };
 
-module.exports = config => {
+module.exports = (config = {}) => {
   config.adminHost = config.adminHost || config.host || configDefaults.host;
   config.proxy = (config.proxy || config.record) === true;
 

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -7,7 +7,7 @@
     "start": "MOCKYEAH_ROOT=. nodemon --inspect index.js --ignore captures",
     "test": "yarn lint && yarn test:coverage",
     "test:watch": "yarn test:unit --watch",
-    "test:unit": "mocha test/**/*Test.js",
+    "test:unit": "mocha test/**/*Test.js test/**/*.test.js",
     "test:coverage": "nyc yarn test:unit",
     "test:coverage:report": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint -c ./eslint.config.js ./app ./lib ./server ./test"

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -58,6 +58,7 @@
   ],
   "devDependencies": {
     "chai": "^3.4.1",
+    "clear-require": "^2.0.0",
     "coveralls": "^3.0.0",
     "dateformat": "^1.0.12",
     "gitbook-plugin-github": "2.0.0",

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -2,9 +2,16 @@
 
 const { expect } = require('chai');
 
+const { MOCKYEAH_ROOT } = process.env;
+process.env.MOCKYEAH_ROOT = '/fake/root';
+
 const prepareConfig = require('../../lib/prepareConfig');
 
 describe('prepareConfig', () => {
+  after(() => {
+    process.env.MOCKYEAH_ROOT = MOCKYEAH_ROOT;
+  });
+
   it('should work and use defaults with no config input', () => {
     const config = prepareConfig();
     expect(config).to.deep.equal({
@@ -12,8 +19,8 @@ describe('prepareConfig', () => {
       adminPort: 4777,
       adminProtocol: 'http',
       adminServer: true,
-      capturesDir: '/Users/anders/code/mockyeah/mockyeah',
-      fixturesDir: '/Users/anders/code/mockyeah/fixtures',
+      capturesDir: '/fake/root/mockyeah',
+      fixturesDir: '/fake/root/fixtures',
       host: 'localhost',
       httpsCertPath: undefined,
       httpsKeyPath: undefined,
@@ -33,8 +40,8 @@ describe('prepareConfig', () => {
       adminPort: 4777,
       adminProtocol: 'http',
       adminServer: true,
-      capturesDir: '/Users/anders/code/mockyeah/mockyeah',
-      fixturesDir: '/Users/anders/code/mockyeah/fixtures',
+      capturesDir: '/fake/root/mockyeah',
+      fixturesDir: '/fake/root/fixtures',
       host: 'localhost',
       httpsCertPath: undefined,
       httpsKeyPath: undefined,

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -26,4 +26,25 @@ describe('prepareConfig', () => {
       verbose: false
     });
   });
+  it('should work and use defaults with empty config input', () => {
+    const config = prepareConfig({});
+    expect(config).to.deep.equal({
+      adminHost: 'localhost',
+      adminPort: 4777,
+      adminProtocol: 'http',
+      adminServer: true,
+      capturesDir: '/Users/anders/code/mockyeah/mockyeah',
+      fixturesDir: '/Users/anders/code/mockyeah/fixtures',
+      host: 'localhost',
+      httpsCertPath: undefined,
+      httpsKeyPath: undefined,
+      journal: false,
+      name: 'mockyeah',
+      output: true,
+      port: 4001,
+      proxy: false,
+      record: false,
+      verbose: false
+    });
+  });
 });

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -1,15 +1,23 @@
 'use strict';
 
+const clearRequire = require('clear-require');
 const { expect } = require('chai');
 
-const { MOCKYEAH_ROOT } = process.env;
-process.env.MOCKYEAH_ROOT = '/fake/root';
-
-const prepareConfig = require('../../lib/prepareConfig');
-
 describe('prepareConfig', () => {
+  let MOCKYEAH_ROOT_BACKUP;
+  let prepareConfig;
+
+  before(() => {
+    clearRequire.all();
+    MOCKYEAH_ROOT_BACKUP = process.env.MOCKYEAH_ROOT;
+    process.env.MOCKYEAH_ROOT = '/fake/root';
+    // eslint-disable-next-line global-require
+    prepareConfig = require('../../lib/prepareConfig');
+  });
+
   after(() => {
-    process.env.MOCKYEAH_ROOT = MOCKYEAH_ROOT;
+    process.env.MOCKYEAH_ROOT = MOCKYEAH_ROOT_BACKUP;
+    clearRequire.all();
   });
 
   it('should work and use defaults with no config input', () => {

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const prepareConfig = require('../../lib/prepareConfig');
+
+describe('prepareConfig', () => {
+  it('should work and use defaults with no config input', () => {
+    const config = prepareConfig();
+    expect(config).to.deep.equal({
+      adminHost: 'localhost',
+      adminPort: 4777,
+      adminProtocol: 'http',
+      adminServer: true,
+      capturesDir: '/Users/anders/code/mockyeah/mockyeah',
+      fixturesDir: '/Users/anders/code/mockyeah/fixtures',
+      host: 'localhost',
+      httpsCertPath: undefined,
+      httpsKeyPath: undefined,
+      journal: false,
+      name: 'mockyeah',
+      output: true,
+      port: 4001,
+      proxy: false,
+      record: false,
+      verbose: false
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,15 +424,31 @@ caching-transform@^1.0.0:
     mkdirp "^0.5.1"
     write-file-atomic "^1.1.4"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  dependencies:
+    callsites "^2.0.0"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
   dependencies:
     callsites "^0.2.0"
 
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  dependencies:
+    caller-callsite "^2.0.0"
+
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -545,6 +561,13 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clear-require@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/clear-require/-/clear-require-2.0.0.tgz#aa01f5c35589326bd55e9869eabda48f86447deb"
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^2.0.0"
 
 cli-boxes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
We were trying to use `config` to apply some defaulting logic, but sometimes `config` isn't defined if you're running purely with the defaults without any config file.