### PR TITLE
chore: add additional ignores for fixtures & captures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
 /captures
+/mockyeah
 /fixtures
+
+/packages/mockyeah-cli/captures
+/packages/mockyeah-cli/mockyeah
+/packages/mockyeah-cli/fixtures
+
+/packages/mockyeah/captures
+/packages/mockyeah/mockyeah
+/packages/mockyeah/fixtures
 
 docs/_book
 


### PR DESCRIPTION
We have to be redundant rather than allow recursive ignore, at least with `mockyeah`, since that folder name is under `packages`.