### PR TITLE
fix: exit on mockyeah record stop enter

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -45,7 +45,10 @@ const withName = (env, name, options = {}) => {
           request.get(`${adminUrl}/record-stop`, () => {});
         } else {
           // eslint-disable-next-line global-require, import/no-dynamic-require
-          require(env.modulePath).recordStop();
+          require(env.modulePath).recordStop(err => {
+            if (err) console.error(err);
+            process.exit(err ? 1 : 0);
+          });
         }
       }
     );


### PR DESCRIPTION
The intent was to automatically exit the CLI prompt for record once you hit enter to stop recording.

In the future we may support one or more of the following features:
* real-time recording (update the capture file with each response)
* a separate `record-stop` command
* record on `ctrl+c` or other process kill
