### PR TITLE
feat: replace encoded protocol characters

### DIFF
--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -4,7 +4,13 @@ const { isEmpty } = require('lodash');
 
 const now = () => new Date().getTime();
 
-const makeRequestUrl = req => req.originalUrl.replace(/^\//, '');
+const openingSlashRegex = /^\//;
+const leadProtocolRegex = /^(https?)%3A%2F%2F/;
+
+const makeRequestUrl = req =>
+  req.originalUrl
+    .replace(openingSlashRegex, '')
+    .replace(leadProtocolRegex, (match, p1) => p1 + '://');
 
 const makeRequestOptions = req => {
   const { headers: _headers, method: _method } = req;
@@ -27,13 +33,13 @@ const makeRequestOptions = req => {
 
   if (!isEmpty(req.body)) {
     options.body = req.body;
-    options.json = typeof req.body === 'object'
+    options.json = typeof req.body === 'object';
   }
 
   return options;
 };
 
-module.exports = (req, res, next) => {
+const proxyRoute = (req, res, next) => {
   const { app } = req;
   const { only } = app.locals.recordMeta;
 
@@ -82,3 +88,8 @@ module.exports = (req, res, next) => {
     }
   }).pipe(res);
 };
+
+// Export for testing purposes.
+proxyRoute.makeRequestUrl = makeRequestUrl;
+
+module.exports = proxyRoute;

--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -10,7 +10,7 @@ const leadProtocolRegex = /^(https?)%3A%2F%2F/;
 const makeRequestUrl = req =>
   req.originalUrl
     .replace(openingSlashRegex, '')
-    .replace(leadProtocolRegex, (match, p1) => p1 + '://');
+    .replace(leadProtocolRegex, (match, p1) => `${p1}://`);
 
 const makeRequestOptions = req => {
   const { headers: _headers, method: _method } = req;

--- a/packages/mockyeah/test/integration/ProxyRouteTest.js
+++ b/packages/mockyeah/test/integration/ProxyRouteTest.js
@@ -1,4 +1,4 @@
-`use strict`;
+'use strict';
 
 const { expect } = require('chai');
 require('../TestHelper');

--- a/packages/mockyeah/test/integration/ProxyRouteTest.js
+++ b/packages/mockyeah/test/integration/ProxyRouteTest.js
@@ -1,0 +1,17 @@
+`use strict`;
+
+const { expect } = require('chai');
+require('../TestHelper');
+const { makeRequestUrl } = require('../../app/proxyRoute');
+
+describe('proxyRoute', () => {
+  describe('makeRequestUrl', () => {
+    it('should decode protocol', () => {
+      expect(
+        makeRequestUrl({
+          originalUrl: 'http%3A%2F%2Fexample.com?otherUrl=http%3A%2F%2Ffoo.com'
+        })
+      ).to.equal('http://example.com?otherUrl=http%3A%2F%2Ffoo.com');
+    });
+  });
+});


### PR DESCRIPTION
It looks like some systems will normalize double slashes in paths, which conflicts with our notion of having the full URL to proxy in the URL path, due to the `//` in the protocol. This change will support decoding an encoded protocol string (`` is translated to `://` internally), so those systems can be supported if they pass an encoded protocol string. This should be safe against any encoded protocols later on in the URL, e.g., in its query parameters, since we only replace a leading occurrence.