### PR TITLE
docs: copy readme to mockyeah package

### DIFF
--- a/packages/mockyeah/README.md
+++ b/packages/mockyeah/README.md
@@ -1,0 +1,15 @@
+# mockyeah
+
+**A powerful service mocking, recording, and playback utility.**
+
+<img src="docs/book/logo/mockyeah.png" height="200" />
+
+[![npm](https://img.shields.io/npm/v/mockyeah.svg)](https://www.npmjs.com/package/mockyeah)
+[![Travis](https://img.shields.io/travis/mockyeah/mockyeah.svg)](https://travis-ci.org/mockyeah/mockyeah)
+[![Coveralls github](https://img.shields.io/coveralls/github/mockyeah/mockyeah.svg)](https://coveralls.io/github/mockyeah/mockyeah)
+
+More at **https://mockyeah.js.org**.
+
+## License
+
+mockyeah is released under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Because `packages/mockyeah` didn't have a `README.md`, which is nice when for npm to show on their site when we publish out there, even though the GitHub repo will still show the identical root-level `README.md`.

I thought maybe Lerna would have some tooling to auto-generate readmes for the sub-packages, maybe based on the `babel` convention, but I didn't see any. Missed this for `0.18.0-alpha.0` (see https://www.npmjs.com/package/mockyeah/v/0.18.0-alpha.0).
