### PR TITLE
feat: support path matching as function & merge queries

### DIFF
--- a/packages/mockyeah/test/integration/RoutePatternTest.js
+++ b/packages/mockyeah/test/integration/RoutePatternTest.js
@@ -170,6 +170,20 @@ describe('Route Patterns', () => {
     });
   });
 
+  it('should match path as function', done => {
+    mockyeah.get(p => p === '/service/exists');
+
+    request.get('/service/exists').expect(200, done);
+  });
+
+  it('should match path as function in object', done => {
+    mockyeah.get({
+      path: p => p === '/service/exists'
+    });
+
+    request.get('/service/exists').expect(200, done);
+  });
+
   it('should work with actual regular expression', done => {
     mockyeah.get(/\/service\/(.{0,})/);
 
@@ -282,6 +296,28 @@ describe('Route Patterns', () => {
     });
 
     request.get('/foo?bar=1').expect(200, done);
+  });
+
+  it('should match merging query parameter in string and object', done => {
+    mockyeah.get({
+      path: '/foo?bar=yes',
+      query: {
+        baz: 'ok'
+      }
+    });
+
+    request.get('/foo?bar=yes&baz=ok').expect(200, done);
+  });
+
+  it('should match merging query parameter in object and string', done => {
+    mockyeah.get({
+      path: '/foo?baz=ok',
+      query: {
+        bar: 'yes'
+      }
+    });
+
+    request.get('/foo?bar=yes&baz=ok').expect(200, done);
   });
 
   it('should match single query parameter in path with object', done => {


### PR DESCRIPTION
Adds support for path patching as a custom function, both as the only argument and within the object.

Also refactors to allow any query parameters in the `path` or `url` option as a string to be merged with any `query` option in the object syntax, with the latter taking precedence, so refactoring matches is easier since you won't have to convert all existing query parameters in the string into the object syntax.

fixes #176 
relates to #173 
