### PR TITLE
feat: support recording with headers

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -37,8 +37,6 @@ const withName = (env, name, options = {}) => {
     options: JSON.stringify(options)
   });
 
-  console.log(options);
-
   let remote;
   request.get(`${adminUrl}/record?${qs}`, err => {
     if (err) {
@@ -82,7 +80,7 @@ boot(env => {
 
   const options = {
     only,
-    header
+    headers: header
   };
 
   if (!name) {

--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -11,17 +11,34 @@ const boot = require('../lib/boot');
 const inquirer = require('inquirer');
 const chalk = require('chalk');
 const request = require('request');
+const querystring = require('querystring');
+
+const collect = (val, memo) => {
+  memo.push(val);
+  return memo;
+};
 
 program
-  .option('-o, --only [regex]', 'only record calls to URLs matching given regex pattern')
+  .option('-o, --only <regex>', 'only record calls to URLs matching given regex pattern')
+  .option(
+    '-h, --header <line>',
+    'record matches will require these headers ("Name: Value")',
+    collect,
+    []
+  )
   .option('-v, --verbose', 'verbose output')
   .parse(process.argv);
 
 const withName = (env, name, options = {}) => {
   const { adminUrl } = env;
 
+  const qs = querystring.stringify({
+    name,
+    options: JSON.stringify(options)
+  });
+
   let remote;
-  request.get(`${adminUrl}/record?name=${name}&options=${JSON.stringify(options)}`, err => {
+  request.get(`${adminUrl}/record?${qs}`, err => {
     if (err) {
       remote = false;
 

--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -37,6 +37,8 @@ const withName = (env, name, options = {}) => {
     options: JSON.stringify(options)
   });
 
+  console.log(options);
+
   let remote;
   request.get(`${adminUrl}/record?${qs}`, err => {
     if (err) {
@@ -74,9 +76,14 @@ global.MOCKYEAH_VERBOSE_OUTPUT = Boolean(program.verbose);
 
 boot(env => {
   const [name] = program.args;
-  const { only } = program;
+  const { only, header } = program;
 
   env.program = program;
+
+  const options = {
+    only,
+    header
+  };
 
   if (!name) {
     inquirer.prompt(
@@ -93,10 +100,10 @@ boot(env => {
           process.exit(1);
         }
 
-        withName(env, answers.name, { only });
+        withName(env, answers.name, options);
       }
     );
   } else {
-    withName(env, name, { only });
+    withName(env, name, options);
   }
 });

--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -13,8 +13,12 @@ const chalk = require('chalk');
 const request = require('request');
 const querystring = require('querystring');
 
+// TODO: write tests for this
 const collect = (val, memo) => {
-  memo.push(val);
+  const pair = val.split(/\s*:\s*/);
+  const key = pair[0];
+  const value = pair[1];
+  memo[key] = value;
   return memo;
 };
 

--- a/packages/mockyeah/app/recorder.js
+++ b/packages/mockyeah/app/recorder.js
@@ -14,6 +14,7 @@ module.exports = app => (name, options = {}) => {
   }
 
   app.locals.recordMeta = {
+    headers: options.headers,
     name,
     options,
     only,

--- a/packages/mockyeah/test/integration/CaptureRecordAndPlayAdminServerTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordAndPlayAdminServerTest.js
@@ -156,4 +156,93 @@ describe('Capture Record and Playback Admin Server', function() {
       done
     );
   });
+
+  it('should record and playback calls matching `headers` option over admin server', function(done) {
+    this.timeout = 10000;
+
+    const captureName = 'some-fancy-capture-3';
+
+    // Construct remote service urls
+    // e.g. http://localhost:4041/http://example.com/some/service
+    const path1 = '/some/service/one';
+
+    // Mount remote service end points
+    remote.get('/some/service/one', { text: 'first' });
+
+    // Initiate recording and playback series
+    async.series(
+      [
+        // Initiate recording
+        cb => {
+          proxyAdminReq
+            .get(
+              `/record?name=${captureName}&options=${encodeURIComponent(
+                JSON.stringify({
+                  headers: {
+                    'X-My-Header': 'My-Value',
+                    'X-My-Header-2': 'My-Value-2'
+                  }
+                })
+              )}`
+            )
+            .expect(204, cb);
+        },
+
+        // Invoke requests to remote services through proxy
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => proxyReq.get(path1).expect(200, 'first', cb),
+
+        // Stop recording but pretend there's a file write error.
+        cb => {
+          const { writeFile } = fs;
+          fs.writeFile = (filePath, js, _cb) => _cb(new Error('fake fs error'));
+          proxy.recordStop(err => {
+            fs.writeFile = writeFile;
+            if (err) {
+              cb();
+              return;
+            }
+            cb(new Error('expected error'));
+          });
+        },
+
+        // Stop recording
+        cb => {
+          proxyAdminReq.get('/record-stop').expect(204, cb);
+        },
+
+        // Assert capture file exists
+        cb => {
+          fs.statSync(getCaptureFilePath(captureName));
+          cb();
+        },
+
+        // Reset proxy services and play captured capture
+        cb => {
+          proxy.reset();
+          cb();
+        },
+
+        cb => {
+          proxyAdminReq.get(`/play?name=${captureName}`).expect(204, cb);
+        },
+
+        // Test remote url paths and their sub paths route to the same services
+        // Assert remote url paths are routed the correct responses
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => remoteReq.get(path1).expect(200, 'first', cb),
+
+        // Assert paths are routed the correct responses
+        // e.g. http://localhost:4041/some/service
+        cb => proxyReq.get(path1).expect(404, cb),
+        cb =>
+          proxyReq
+            .get(path1)
+            .set('X-My-Header', 'My-Value')
+            .set('X-My-Header-2', 'My-Value-2')
+            .expect(200, cb)
+      ],
+      done
+    );
+  });
 });

--- a/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
@@ -241,10 +241,95 @@ describe('Capture Record and Playback', function() {
 
         // Assert paths are routed the correct responses
         // e.g. http://localhost:4041/some/service
-        cb => proxyReq.get(path1).expect(500, cb),
-        cb => proxyReq.get(path2).expect(500, cb),
+        cb => proxyReq.get(path1).expect(404, cb),
+        cb => proxyReq.get(path2).expect(404, cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, 'fourth', cb)
+      ],
+      done
+    );
+  });
+
+  it('should record and playback calls matching `headers` option', function(done) {
+    this.timeout = 10000;
+
+    const captureName = 'some-fancy-capture-3';
+
+    // Construct remote service urls
+    // e.g. http://localhost:4041/http://example.com/some/service
+    const path1 = '/some/service/one';
+
+    // Mount remote service end points
+    remote.get('/some/service/one', { text: 'first' });
+
+    // Initiate recording and playback series
+    async.series(
+      [
+        // Initiate recording
+        cb => {
+          proxy.record(captureName, {
+            headers: {
+              'X-My-Header': 'My-Value',
+              'X-My-Header-2': 'My-Value-2'
+            }
+          });
+          cb();
+        },
+
+        // Invoke requests to remote services through proxy
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => proxyReq.get(path1).expect(200, 'first', cb),
+
+        // Stop recording but pretend there's a file write error.
+        cb => {
+          const { writeFile } = fs;
+          fs.writeFile = (filePath, js, _cb) => _cb(new Error('fake fs error'));
+          proxy.recordStop(err => {
+            fs.writeFile = writeFile;
+            if (err) {
+              cb();
+              return;
+            }
+            cb(new Error('expected error'));
+          });
+        },
+
+        // Stop recording
+        cb => {
+          proxy.recordStop(cb);
+        },
+
+        // Assert capture file exists
+        cb => {
+          fs.statSync(getCaptureFilePath(captureName));
+          cb();
+        },
+
+        // Reset proxy services and play captured capture
+        cb => {
+          proxy.reset();
+          cb();
+        },
+
+        cb => {
+          proxy.play(captureName);
+          cb();
+        },
+
+        // Test remote url paths and their sub paths route to the same services
+        // Assert remote url paths are routed the correct responses
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => remoteReq.get(path1).expect(200, 'first', cb),
+
+        // Assert paths are routed the correct responses
+        // e.g. http://localhost:4041/some/service
+        cb => proxyReq.get(path1).expect(404, cb),
+        cb =>
+          proxyReq
+            .get(path1)
+            .set('X-My-Header', 'My-Value')
+            .set('X-My-Header-2', 'My-Value-2')
+            .expect(200, cb)
       ],
       done
     );


### PR DESCRIPTION
Adds support for a record option for headers. This will mix in the provided default headers into the match objects for recorded captures. This would support the opt-in suite-based features we have been discussing.

This is optionally provided as a `headers` object in the API, and as zero to many `--header 'Key: Value` flags in the CLI.

Added TODO comment to add tests to the CLI project, but in lieu of that for now, here's proof that at least the `collect` method works:

<img width="265" alt="screen shot 2018-10-16 at 12 04 51 am" src="https://user-images.githubusercontent.com/615381/46993874-5e185880-d0d7-11e8-920d-8e13a7342948.png">

fixes #151 