### PR TITLE
chore(release): publish v0.18.0-alpha.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/mockyeah",
     "packages/mockyeah-cli"
   ],
-  "version": "0.18.0-alpha.0"
+  "version": "0.18.0-alpha.1"
 }

--- a/packages/mockyeah-cli/package.json
+++ b/packages/mockyeah-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockyeah-cli",
-  "version": "0.18.0-alpha.0",
+  "version": "0.18.0-alpha.1",
   "description": "A powerful service mocking, recording, and playback utility.",
   "main": "index.js",
   "bin": {
@@ -24,7 +24,7 @@
     "v8flags": "^2.0.11"
   },
   "devDependencies": {
-    "mockyeah": "^0.18.0-alpha.0"
+    "mockyeah": "^0.18.0-alpha.1"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockyeah",
-  "version": "0.18.0-alpha.0",
+  "version": "0.18.0-alpha.1",
   "description": "A powerful service mocking, recording, and playback utility.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Corresponds with https://github.com/mockyeah/mockyeah/releases/tag/v0.18.0-alpha.1.
Published with:
```console
$ lerna version prerelease
```
```console
$ NPM_CONFIG_OTP=XXXXXX lerna publish from-git --npm-tag next
```
