### PR TITLE
fix(mockyeah-cli): default headers to object

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -28,7 +28,7 @@ program
     '-h, --header <line>',
     'record matches will require these headers ("Name: Value")',
     collect,
-    []
+    {}
   )
   .option('-v, --verbose', 'verbose output')
   .parse(process.argv);


### PR DESCRIPTION
Fixes a bug where headers should have been defaulted to an object, not an array.