### PR TITLE
fix: delete transfer-encoding for recording

### DIFF
--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -78,9 +78,12 @@ const proxyRoute = (req, res, next) => {
 
     const latency = now() - startTime;
 
-    const headers = {
-      ...__headers
-    };
+    const headers = Object.assign(
+      {},
+      {
+        __headers
+      }
+    );
 
     // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
     delete headers['transfer-encoding'];

--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -23,9 +23,6 @@ const makeRequestOptions = req => {
 
   // TODO: Should we support an option to rewrite `origin` header?
 
-  // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
-  delete headers['transfer-encoding'];
-
   const reqUrl = makeRequestUrl(req);
 
   const options = {
@@ -77,9 +74,16 @@ const proxyRoute = (req, res, next) => {
 
     const { method, body: reqBody } = req;
 
-    const { statusCode: status, _headers: headers } = res;
+    const { statusCode: status, _headers: __headers } = res;
 
     const latency = now() - startTime;
+
+    const headers = {
+      ...__headers
+    };
+
+    // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
+    delete headers['transfer-encoding'];
 
     app.locals.recordMeta.set.push([
       {


### PR DESCRIPTION
I flubbed the last PR (#188) deleting from the wrong headers object - probably an indication that we should modularize `proxyRoute.js` better.