### PR TITLE
chore: add script for coverage report html

### DIFF
--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -9,6 +9,7 @@
     "test:watch": "yarn test:unit --watch",
     "test:unit": "mocha test/**/*Test.js test/**/*.test.js",
     "test:coverage": "nyc yarn test:unit",
+    "test:coverage:report:html": "nyc yarn test:unit && nyc report --reporter=html",
     "test:coverage:report": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint -c ./eslint.config.js ./app ./lib ./server ./test"
   },


### PR DESCRIPTION
This script `yarn test:coverage:report:html` generates an HTML coverage report locally. After running, you can open with `chrome coverage/index.html`.