### PR TITLE
docs: fix links (and some auto-formatting)

### DIFF
--- a/docs/book/API/Expectation-API.md
+++ b/docs/book/API/Expectation-API.md
@@ -5,21 +5,21 @@ The Expectation API enables you to verify your integration via the perspective o
 Example:
 
 ```js
-const mockyeah = require('mockyeah');
-const request = require('supertest');
+const mockyeah = require("mockyeah");
+const request = require("supertest");
 
-describe('This test', () => {
-  it('should verify service is called once with parameter', done => {
+describe("This test", () => {
+  it("should verify service is called once with parameter", done => {
     const expectation = mockyeah
-      .get('/say-hello', { text: 'hello' })
+      .get("/say-hello", { text: "hello" })
       .expect()
       .params({
-        foo: 'bar'
+        foo: "bar"
       })
       .once();
 
-    request('http://localhost:4040')
-      .get('/say-hello?foo=bar')
+    request("http://localhost:4040")
+      .get("/say-hello?foo=bar")
       .expect(200, () => {
         expectation.verify();
         done();
@@ -29,7 +29,7 @@ describe('This test', () => {
 ```
 
 <div id="expect"></div>
-`.expect()` - Returns an expectation object for a given mock service when chained to a [Mock Services API](Mock-API.md) method call.
+`.expect()` - Returns an expectation object for a given mock service when chained to a [Mock Services API](./Mock-API.md) method call.
 
 <div id="atLeast">
 `.atLeast(Number)` - Adds expectation that a service must be called at least a specified number of times.
@@ -57,10 +57,10 @@ describe('This test', () => {
 
 ```js
 const expectation = mockyeah
-  .get('/say-hello', { text: 'hello' })
+  .get("/say-hello", { text: "hello" })
   .expect()
   .body({
-    foo: 'bar'
+    foo: "bar"
   });
 ```
 
@@ -69,10 +69,10 @@ const expectation = mockyeah
 
 ```js
 const expectation = mockyeah
-  .get('/say-hello', { text: 'hello' })
+  .get("/say-hello", { text: "hello" })
   .expect()
   .params({
-    id: '9999'
+    id: "9999"
   });
 ```
 
@@ -81,9 +81,9 @@ const expectation = mockyeah
 
 ```js
 const expectation = mockyeah
-  .get('/say-hello', { text: 'hello' })
+  .get("/say-hello", { text: "hello" })
   .expect()
-  .header('host', 'example.com');
+  .header("host", "example.com");
 ```
 
 <div id="verify"></div>
@@ -101,21 +101,21 @@ Examples:
 
 ```js
 const expectation = mockyeah
-  .get('/foo', { text: 'bar' })
+  .get("/foo", { text: "bar" })
   .expect()
-  .header('X-API-Key', value => /[0-9A-F]{32}/i.test(value));
+  .header("X-API-Key", value => /[0-9A-F]{32}/i.test(value));
 ```
 
 ```js
 const expectation = mockyeah
-  .get('/foo', { text: 'bar' })
+  .get("/foo", { text: "bar" })
   .expect()
-  .params(params => params.someParam === 'yes');
+  .params(params => params.someParam === "yes");
 ```
 
 ```js
 const expectation = mockyeah
-  .get('/foo', { text: 'bar' })
+  .get("/foo", { text: "bar" })
   .expect()
-  .body(body => body.id === '123');
+  .body(body => body.id === "123");
 ```

--- a/docs/book/API/proxy.md
+++ b/docs/book/API/proxy.md
@@ -2,4 +2,4 @@
 
 `mockyeah.proxy()`
 
-Dynamically enables the `proxy` configuration option. See [Configuration](Configuration.md).
+Dynamically enables the `proxy` configuration option. See [Configuration](../Configuration.md).

--- a/docs/book/API/record.md
+++ b/docs/book/API/record.md
@@ -6,7 +6,7 @@
 (i.e. `./mockyeah/[snapshot name]`).
 
 Configures mockyeah to proxy and capture service requests. Recorded responses
-will be written when you call [`recordStop`](API/recordStop.md).
+will be written when you call [`recordStop`](./recordStop.md).
 To use this feature, you can update the service addresses in your application
 to proxy through mockyeah. Here is an example of an address configured for recording:
 

--- a/docs/book/API/recordStop.md
+++ b/docs/book/API/recordStop.md
@@ -3,6 +3,6 @@
 `mockyeah.recordStop()`
 
 Configures mockyeah to stop recording and capturing service requests,
-to be called after a call to [`record`](API/record.md).
+to be called after a call to [`record`](./record.md).
 Recorded responses are written to `./mockyeah`
-(or `config.capturesDir` - see [Configuration](Configuration.md)).
+(or `config.capturesDir` - see [Configuration](../Configuration.md)).

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -18,10 +18,10 @@ Have a requirement to implement specific behavior when a service is slow to resp
 
 ## What is mockyeah's purpose?
 
-* To eliminate service side effects, increasing test durability
-* To provide dependable integrations
-* To isolate application behavior
-* To increase developer productivity
-* To increase integration testing performance by eliminating network latency
+- To eliminate service side effects, increasing test durability
+- To provide dependable integrations
+- To isolate application behavior
+- To increase developer productivity
+- To increase integration testing performance by eliminating network latency
 
-To begin, see our [Getting Started](Getting-Started.md) guide.
+To begin, see our [Getting Started](./Getting-Started.md) guide.

--- a/docs/book/Snapshots/Overview.md
+++ b/docs/book/Snapshots/Overview.md
@@ -4,9 +4,9 @@ mockyeah provides the ability to capture service snapshots from real services an
 While recording, mockyeah proxies all received requests to configured hosts and captures their responses as snapshots.
 Snapshots include: response body, method, headers, status code, latency, and path.
 
-See [`record`](API/record.md), [`recordStop`](API/recordStop.md), and [`play`](API/play.md).
+See [`record`](../API/record.md), [`recordStop`](../API/recordStop.md), and [`play`](../API/play.md).
 
-See also our section on the [CLI](CLI/CLI.md)
+See also our section on the [CLI](../CLI/CLI.md)
 for another way to record and play.
 
 ## Ad Hoc Snapshots


### PR DESCRIPTION
Some fixes to documentation links between pages. Also my editor auto-formatted some of these pages and I'm to lazy right now to isolate my changes with an interactive add or continue to tiptoe around readme files with my default editor settings - let me know if that's an issue.