### PR TITLE
fix: record stop error handling

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -33,6 +33,11 @@ program
   .option('-v, --verbose', 'verbose output')
   .parse(process.argv);
 
+const recordStopCallback = err => {
+  if (err) console.error(err);
+  process.exit(err ? 1 : 0);
+};
+
 const withName = (env, name, options = {}) => {
   const { adminUrl } = env;
 
@@ -63,13 +68,10 @@ const withName = (env, name, options = {}) => {
       ],
       () => {
         if (remote) {
-          request.get(`${adminUrl}/record-stop`, () => {});
+          request.get(`${adminUrl}/record-stop`, recordStopCallback);
         } else {
           // eslint-disable-next-line global-require, import/no-dynamic-require
-          require(env.modulePath).recordStop(err => {
-            if (err) console.error(err);
-            process.exit(err ? 1 : 0);
-          });
+          require(env.modulePath).recordStop(recordStopCallback);
         }
       }
     );


### PR DESCRIPTION
There was a lint error here relating to nested `err` variables. Turns out we probably should've been handling errors for the remote call anyway, so I've extracted the shared logic to fix both issues.