### PR TITLE
feat: record json

### DIFF
--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -5,4 +5,23 @@ function resolveFilePath(capturePath, url) {
   return path.resolve(capturePath, fileName);
 }
 
+const handleContentType = (body, headers) => {
+  const contentType = headers['content-type'];
+
+  // TODO: More spec-conformant detection of JSON content type.
+  if (contentType && contentType.includes('/json')) {
+    try {
+      const json = JSON.parse(body);
+      return {
+        json
+      };
+    } catch (err) {} // silence any errors, invalid JSON is ok
+  }
+
+  return {
+    raw: body
+  };
+};
+
+exports.handleContentType = handleContentType;
 exports.resolveFilePath = resolveFilePath;

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -15,7 +15,8 @@ const handleContentType = (body, headers) => {
       return {
         json
       };
-    } catch (err) {} // silence any errors, invalid JSON is ok
+    } // eslint-disable-next-line no-empty
+    catch (err) {} // silence any errors, invalid JSON is ok
   }
 
   return {

--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -1,6 +1,7 @@
 const request = require('request');
 const isAbsoluteUrl = require('is-absolute-url');
 const { isEmpty } = require('lodash');
+const { handleContentType } = require('./lib/helpers');
 
 const now = () => new Date().getTime();
 
@@ -104,15 +105,16 @@ const proxyRoute = (req, res, next) => {
     // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
     delete headers['transfer-encoding'];
 
-    recordMeta.set.push([
-      match,
+    const options = Object.assign(
       {
         headers,
         status,
-        raw: _body, // TODO: Support JSON response deserialized
         latency
-      }
-    ]);
+      },
+      handleContentType(_body, headers)
+    );
+
+    recordMeta.set.push([match, options]);
   }).pipe(res);
 };
 

--- a/packages/mockyeah/test/unit/helpers.test.js
+++ b/packages/mockyeah/test/unit/helpers.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const { handleContentType } = require('../../app/lib/helpers');
+
+describe('app helpers', () => {
+  describe('handleContentType', () => {
+    it('gives raw with no content-type header', () => {
+      const body = 'some body';
+      const headers = {};
+      expect(handleContentType(body, headers)).to.deep.equal({
+        raw: body
+      });
+    });
+
+    it('gives raw with text content-type', () => {
+      const body = 'some body';
+      const headers = {
+        'content-type': 'text/plain'
+      };
+      expect(handleContentType(body, headers)).to.deep.equal({
+        raw: body
+      });
+    });
+
+    it('gives json with json content-type', () => {
+      const body = '{"foo":"bar"}';
+      const headers = {
+        'content-type': 'application/json'
+      };
+      expect(handleContentType(body, headers)).to.deep.equal({
+        json: {
+          foo: 'bar'
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds feature to support recording to mock suites using `json` with a parsed JSON object as the value of the body instead of always using `raw` with the string value of the body. This makes it easier to work with the mock suites when editing response bodies manually after recording, and formats the generated suite source code more nicely.