### PR TITLE
fix: some logs show urls

### DIFF
--- a/packages/mockyeah/app/lib/RouteManager.js
+++ b/packages/mockyeah/app/lib/RouteManager.js
@@ -11,7 +11,7 @@ module.exports = function RouteManager(app) {
 
   return {
     register: function register(method, _path, response) {
-      app.log(['serve', 'mount', method], _path.path || _path);
+      app.log(['serve', 'mount', method], _path.path || _path.url || _path);
       return routeResolver.register(method, _path, response);
     },
 

--- a/packages/mockyeah/app/recordStopper.js
+++ b/packages/mockyeah/app/recordStopper.js
@@ -40,7 +40,7 @@ module.exports = app => cb => {
     }
 
     set.forEach(capture => {
-      app.log(['record', 'response', 'saved'], capture[0].url);
+      app.log(['record', 'response', 'saved'], capture[0].path || capture[0].url || capture[0]);
     });
 
     if (typeof app.locals.proxyingBeforeRecording !== 'undefined') {


### PR DESCRIPTION
Some logs weren't printing URLs correctly for object syntax since we support both `path` and `url` as well as string URLs now. Perhaps the ideal solution would be to manipulate the different syntaxes to a normalized schema for internal use, but this will work for now.