### PR TITLE
feat: record to fixture file (path or require)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /packages/mockyeah/captures
 /packages/mockyeah/mockyeah
 /packages/mockyeah/fixtures
+/packages/mockyeah/test/fixtures/test-*
 
 docs/_book
 

--- a/docs/book/Configuration.md
+++ b/docs/book/Configuration.md
@@ -16,7 +16,9 @@
   "record": false,
   "adminServer": true,
   "adminHost": "localhost",
-  "adminPort": 4777
+  "adminPort": 4777,
+  "recordToFixtures": false,
+  "recordToFixturesMode": "path"
 }
 ```
 
@@ -83,6 +85,10 @@ Internally, this mounts with a leading slash, i.e., `'/https://service.example.c
 - `adminServer`: Boolean to enable admin server (for recording, playing, etc.)
 - `adminHost`: Host on which admin server will run.
 - `adminPort`: Port on which admin server will run.
+- `recordToFixtures`: Whether to record captures with response bodies written to separate files in the fixtures directory vs. inlined into the capture files.
+- `recordToFixturesMode`: When `recordToFixtures` is enabled, which mode to use to refer to fixture files
+  - "path" (default): Use the response option of `fixture` with the path to the fixture file as a string.
+  - "require": For JSON fixtures, use the response option of `json` with an inline `require` of the JSON file using a relative path, otherwise fallback to "path" mode (may support custom `require`-able files in the future for users with custom setups, e.g., Webpack loaders).
 
 ### HTTPS
 

--- a/docs/book/Configuration.md
+++ b/docs/book/Configuration.md
@@ -17,7 +17,7 @@
   "adminServer": true,
   "adminHost": "localhost",
   "adminPort": 4777,
-  "recordToFixtures": false,
+  "recordToFixtures": true,
   "recordToFixturesMode": "path"
 }
 ```
@@ -72,9 +72,9 @@ Then you can hit your mockyeah server's URLs like:
 and allow the first to pass through to the actual origin by not defining any mocks, but mock the second with:
 
 ```js
-mockyeah.get('https://service.example.com/foo/bar', {
+mockyeah.get("https://service.example.com/foo/bar", {
   json: {
-    hello: 'there'
+    hello: "there"
   }
 });
 ```

--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -23,6 +23,7 @@ const collect = (val, memo) => {
 };
 
 program
+  .option('-f, --fixtures', 'record to fixture files instead of inlining response bodies')
   .option('-o, --only <regex>', 'only record calls to URLs matching given regex pattern')
   .option(
     '-h, --header <line>',
@@ -81,13 +82,14 @@ global.MOCKYEAH_VERBOSE_OUTPUT = Boolean(program.verbose);
 
 boot(env => {
   const [name] = program.args;
-  const { only, header } = program;
+  const { only, header, fixtures } = program;
 
   env.program = program;
 
   const options = {
     only,
-    headers: header
+    headers: header,
+    recordToFixtures: fixtures
   };
 
   if (!name) {

--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -23,7 +23,6 @@ const collect = (val, memo) => {
 };
 
 program
-  .option('-f, --fixtures', 'record to fixture files instead of inlining response bodies')
   .option('-o, --only <regex>', 'only record calls to URLs matching given regex pattern')
   .option(
     '-h, --header <line>',
@@ -82,14 +81,13 @@ global.MOCKYEAH_VERBOSE_OUTPUT = Boolean(program.verbose);
 
 boot(env => {
   const [name] = program.args;
-  const { only, header, fixtures } = program;
+  const { only, header } = program;
 
   env.program = program;
 
   const options = {
     only,
-    headers: header,
-    recordToFixtures: fixtures
+    headers: header
   };
 
   if (!name) {

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -10,13 +10,16 @@ const handleContentType = (body, headers) => {
 
   // TODO: More spec-conformant detection of JSON content type.
   if (contentType && contentType.includes('/json')) {
+    /* eslint-disable no-empty */
     try {
       const json = JSON.parse(body);
       return {
         json
       };
-    } // eslint-disable-next-line no-empty
-    catch (err) {} // silence any errors, invalid JSON is ok
+    } catch (err) {
+      // silence any errors, invalid JSON is ok
+    }
+    /* eslint-enable no-empty */
   }
 
   return {

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -5,4 +5,23 @@ function resolveFilePath(capturePath, url) {
   return path.resolve(capturePath, fileName);
 }
 
+const handleContentType = (body, headers) => {
+  const contentType = headers['content-type'];
+
+  // TODO: More spec-conformant detection of JSON content type.
+  if (contentType && contentType.includes('/json')) {
+    try {
+      const json = JSON.parse(body);
+      return {
+        json
+      };
+    } catch (err) {} // silence any errors, invalid JSON is ok
+  }
+
+  return {
+    raw: body
+  };
+};
+
+exports.handleContentType = handleContentType;
 exports.resolveFilePath = resolveFilePath;

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -15,7 +15,8 @@ const handleContentType = (body, headers) => {
       return {
         json
       };
-    } catch (err) {} // silence any errors, invalid JSON is ok
+    } // eslint-disable-next-line no-empty
+    catch (err) {} // silence any errors, invalid JSON is ok
   }
 
   return {

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -27,5 +27,38 @@ const handleContentType = (body, headers) => {
   };
 };
 
+const replaceFixtureWithRequireInJson = (json, { relativePath }) =>
+  json.replace(
+    /"fixture"(\s*):(\s*)"([^"]+)\.json"/g,
+    `"json"$1:$2require("${relativePath}/$3.json")`
+  );
+
+const getDataForRecordToFixtures = ({ responseOptions, name, index }) => {
+  const newResponseOptions = Object.assign({}, responseOptions);
+
+  const { raw, json } = responseOptions;
+
+  const fixtureName = `${name}/${index}`;
+
+  let body;
+
+  if (raw) {
+    newResponseOptions.fixture = `${fixtureName}.txt`;
+    body = raw;
+    delete newResponseOptions.raw;
+  } else if (json) {
+    newResponseOptions.fixture = `${fixtureName}.json`;
+    body = JSON.stringify(json, null, 2);
+    delete newResponseOptions.json;
+  }
+
+  return {
+    newResponseOptions,
+    body
+  };
+};
+
+exports.getDataForRecordToFixtures = getDataForRecordToFixtures;
+exports.replaceFixtureWithRequireInJson = replaceFixtureWithRequireInJson;
 exports.handleContentType = handleContentType;
 exports.resolveFilePath = resolveFilePath;

--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -1,6 +1,7 @@
 const request = require('request');
 const isAbsoluteUrl = require('is-absolute-url');
 const { isEmpty } = require('lodash');
+const { handleContentType } = require('./lib/helpers');
 
 const now = () => new Date().getTime();
 
@@ -104,15 +105,16 @@ const proxyRoute = (req, res, next) => {
     // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
     delete headers['transfer-encoding'];
 
-    recordMeta.set.push([
-      match,
+    const options = Object.assign(
       {
         headers,
         status,
-        raw: _body, // TODO: Support JSON response deserialized
         latency
-      }
-    ]);
+      },
+      handleContentType(_body, headers)
+    );
+
+    recordMeta.set.push([match, options]);
   }).pipe(res);
 };
 

--- a/packages/mockyeah/app/recordStopper.js
+++ b/packages/mockyeah/app/recordStopper.js
@@ -52,9 +52,11 @@ module.exports = app => cb => {
 
         const fixturesPath = path.join(fixturesDir, fixture);
 
+        // TODO: Any easy way to coordinate this asynchronously?
         // eslint-disable-next-line no-sync
         mkdirp.sync(path.join(fixturesDir, name));
 
+        // TODO: Any easy way to coordinate this asynchronously?
         // eslint-disable-next-line no-sync
         fs.writeFileSync(fixturesPath, body);
       }

--- a/packages/mockyeah/app/recordStopper.js
+++ b/packages/mockyeah/app/recordStopper.js
@@ -11,23 +11,66 @@ module.exports = app => cb => {
   }
 
   const {
-    recordMeta: { name, set }
+    recordMeta: { name, set, recordToFixtures, recordToFixturesMode }
   } = app.locals;
 
   if (!name) throw new Error('Not recording.');
 
-  const { capturesDir } = app.config;
+  const { capturesDir, fixturesDir } = app.config;
+
   const capturePath = path.join(capturesDir, name);
 
   mkdirp.sync(capturePath);
 
   const filePath = resolveFilePath(capturePath, 'index.js');
 
-  set.forEach(capture => {
-    app.log(['serve', 'capture'], capture[0].url);
+  set.forEach((capture, index) => {
+    const [match, responseOptions] = capture;
+
+    app.log(['serve', 'capture'], match.url || match.path || match);
+
+    if (recordToFixtures) {
+      const { raw, json } = responseOptions;
+
+      const fixtureName = `${name}/${index}`;
+
+      let fixture;
+      let body;
+
+      if (raw) {
+        fixture = `${fixtureName}.txt`;
+        body = raw;
+        delete responseOptions.raw;
+      } else if (json) {
+        fixture = `${fixtureName}.json`;
+        body = JSON.stringify(json, null, 2);
+        delete responseOptions.json;
+      }
+
+      if (fixture) {
+        responseOptions.fixture = fixture;
+
+        const fixturesPath = path.join(fixturesDir, fixture);
+
+        // eslint-disable-next-line no-sync
+        mkdirp.sync(path.join(fixturesDir, name));
+
+        // eslint-disable-next-line no-sync
+        fs.writeFileSync(fixturesPath, body);
+      }
+    }
   });
 
-  const json = JSON.stringify(set, null, 2);
+  let json = JSON.stringify(set, null, 2);
+
+  if (recordToFixturesMode === 'require') {
+    const relativePath = path.relative(capturePath, fixturesDir);
+    json = json.replace(
+      /"fixture"(\s*):(\s*)"([^"]+)\.json"/g,
+      `"json"$1:$2require("${relativePath}/$3.json")`
+    );
+  }
+
   const js = `module.exports = ${json};`;
 
   fs.writeFile(filePath, js, err => {

--- a/packages/mockyeah/app/recordStopper.js
+++ b/packages/mockyeah/app/recordStopper.js
@@ -10,8 +10,10 @@ module.exports = app => cb => {
     return;
   }
 
+  const { recordToFixtures, recordToFixturesMode } = app.config;
+
   const {
-    recordMeta: { name, set, recordToFixtures, recordToFixturesMode }
+    recordMeta: { name, set }
   } = app.locals;
 
   if (!name) throw new Error('Not recording.');

--- a/packages/mockyeah/app/recorder.js
+++ b/packages/mockyeah/app/recorder.js
@@ -1,7 +1,17 @@
 module.exports = app => (name, options = {}) => {
   let only;
+  let recordToFixtures;
+
+  if (typeof options.recordToFixtures !== 'undefined') {
+    // eslint-disable-next-line prefer-destructuring
+    recordToFixtures = options.recordToFixtures;
+  } else {
+    // eslint-disable-next-line prefer-destructuring
+    recordToFixtures = app.config.recordToFixtures;
+  }
 
   app.locals.recording = true;
+
   if (!name) throw new Error('Must provide a recording name.');
 
   app.log(['serve', 'record'], name);
@@ -18,7 +28,8 @@ module.exports = app => (name, options = {}) => {
     name,
     options,
     only,
-    set: []
+    set: [],
+    recordToFixtures
   };
 
   // Store whether we're proxying so we can reset it later.

--- a/packages/mockyeah/app/recorder.js
+++ b/packages/mockyeah/app/recorder.js
@@ -1,14 +1,5 @@
 module.exports = app => (name, options = {}) => {
   let only;
-  let recordToFixtures;
-
-  if (typeof options.recordToFixtures !== 'undefined') {
-    // eslint-disable-next-line prefer-destructuring
-    recordToFixtures = options.recordToFixtures;
-  } else {
-    // eslint-disable-next-line prefer-destructuring
-    recordToFixtures = app.config.recordToFixtures;
-  }
 
   app.locals.recording = true;
 
@@ -23,13 +14,14 @@ module.exports = app => (name, options = {}) => {
     app.log(['serve', 'record', 'only'], regex);
   }
 
+  const { headers } = options;
+
   app.locals.recordMeta = {
-    headers: options.headers,
+    headers,
     name,
     options,
     only,
-    set: [],
-    recordToFixtures
+    set: []
   };
 
   // Store whether we're proxying so we can reset it later.

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -18,7 +18,7 @@ const configDefaults = {
   adminProtocol: 'http',
   adminHost: 'localhost',
   adminPort: 4777,
-  recordToFixtures: false,
+  recordToFixtures: true,
   recordToFixturesMode: 'path'
 };
 

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -17,7 +17,9 @@ const configDefaults = {
   // TODO: Implement support for HTTPS admin server protocol.
   adminProtocol: 'http',
   adminHost: 'localhost',
-  adminPort: 4777
+  adminPort: 4777,
+  recordToFixtures: false,
+  recordToFixturesMode: 'path'
 };
 
 module.exports = (config = {}) => {

--- a/packages/mockyeah/test/integration/CaptureRecordAndPlayAdminServerTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordAndPlayAdminServerTest.js
@@ -72,7 +72,7 @@ describe('Capture Record and Playback Admin Server', function() {
   it('should record and playback capture over admin server', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture';
+    const captureName = 'test-some-fancy-admin-server-capture';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -160,7 +160,7 @@ describe('Capture Record and Playback Admin Server', function() {
   it('should record and playback calls matching `headers` option over admin server', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture-3';
+    const captureName = 'test-some-fancy-admin-server-capture-3';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -249,7 +249,7 @@ describe('Capture Record and Playback Admin Server', function() {
   it('should record and playback capture with playAll over admin server', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture-all';
+    const captureName = 'test-some-fancy-admin-server-capture-all';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service

--- a/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
@@ -55,7 +55,7 @@ describe('Capture Record and Playback', function() {
   afterEach(() => {
     proxy.reset();
     remote.reset();
-    // rimraf.sync(PROXY_CAPTURES_DIR);
+    rimraf.sync(PROXY_CAPTURES_DIR);
   });
 
   after(() => {

--- a/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
@@ -165,7 +165,7 @@ describe('Capture Record and Playback', function() {
         // Assert paths are routed the correct responses
         // e.g. http://localhost:4041/some/service
         cb => proxyReq.get(path1).expect(200, 'first', cb),
-        cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
+        cb => proxyReq.get(path2).expect(200, '{\n  "second": true\n}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, cb),
         cb =>
@@ -513,7 +513,7 @@ describe('Capture Record and Playback', function() {
         // Assert paths are routed the correct responses
         // e.g. http://localhost:4041/some/service
         cb => proxyReq.get(path1).expect(200, 'first', cb),
-        cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
+        cb => proxyReq.get(path2).expect(200, '{\n  "second": true\n}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, 'fourth', cb),
         cb => proxyReq.get(path5).expect(200, 'fifth', cb)

--- a/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
@@ -55,7 +55,7 @@ describe('Capture Record and Playback', function() {
   afterEach(() => {
     proxy.reset();
     remote.reset();
-    rimraf.sync(PROXY_CAPTURES_DIR);
+    // rimraf.sync(PROXY_CAPTURES_DIR);
   });
 
   after(() => {
@@ -70,7 +70,7 @@ describe('Capture Record and Playback', function() {
   it('should record and playback capture', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture';
+    const captureName = 'test-some-fancy-capture';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -82,7 +82,7 @@ describe('Capture Record and Playback', function() {
 
     // Mount remote service end points
     remote.get('/some/service/one', { text: 'first' });
-    remote.get('/some/service/two', { text: 'second' });
+    remote.get('/some/service/two', { json: { second: true } });
     remote.get('/some/service/three', { text: 'third', headers: {} });
     remote.get('/some/service/four');
     remote.post('/some/service/five', {
@@ -104,7 +104,7 @@ describe('Capture Record and Playback', function() {
         // Invoke requests to remote services through proxy
         // e.g. http://localhost:4041/http://example.com/some/service
         cb => proxyReq.get(path1).expect(200, 'first', cb),
-        cb => proxyReq.get(path2).expect(200, 'second', cb),
+        cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, cb),
         cb =>
@@ -153,7 +153,7 @@ describe('Capture Record and Playback', function() {
         // Assert remote url paths are routed the correct responses
         // e.g. http://localhost:4041/http://example.com/some/service
         cb => remoteReq.get(path1).expect(200, 'first', cb),
-        cb => remoteReq.get(path2).expect(200, 'second', cb),
+        cb => remoteReq.get(path2).expect(200, '{"second":true}', cb),
         cb => remoteReq.get(path3).expect(200, 'third', cb),
         cb => remoteReq.get(path4).expect(200, cb),
         cb =>
@@ -165,7 +165,7 @@ describe('Capture Record and Playback', function() {
         // Assert paths are routed the correct responses
         // e.g. http://localhost:4041/some/service
         cb => proxyReq.get(path1).expect(200, 'first', cb),
-        cb => proxyReq.get(path2).expect(200, 'second', cb),
+        cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, cb),
         cb =>
@@ -181,7 +181,7 @@ describe('Capture Record and Playback', function() {
   it('should record and playback calls matching `only` option', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture-2';
+    const captureName = 'test-some-fancy-capture-2';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -192,7 +192,7 @@ describe('Capture Record and Playback', function() {
 
     // Mount remote service end points
     remote.get('/some/service/one', { text: 'first' });
-    remote.get('/some/service/two', { text: 'second' });
+    remote.get('/some/service/two', { json: { second: true } });
     remote.get('/some/service/three', { text: 'third' });
     remote.get('/some/service/three/:id', { text: 'fourth' });
 
@@ -208,7 +208,7 @@ describe('Capture Record and Playback', function() {
         // Invoke requests to remote services through proxy
         // e.g. http://localhost:4041/http://example.com/some/service
         cb => proxyReq.get(path1).expect(200, 'first', cb),
-        cb => proxyReq.get(path2).expect(200, 'second', cb),
+        cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, 'fourth', cb),
 
@@ -252,7 +252,7 @@ describe('Capture Record and Playback', function() {
         // Assert remote url paths are routed the correct responses
         // e.g. http://localhost:4041/http://example.com/some/service
         cb => remoteReq.get(path1).expect(200, 'first', cb),
-        cb => remoteReq.get(path2).expect(200, 'second', cb),
+        cb => remoteReq.get(path2).expect(200, '{"second":true}', cb),
         cb => remoteReq.get(path3).expect(200, 'third', cb),
         cb => remoteReq.get(path4).expect(200, 'fourth', cb),
 
@@ -270,7 +270,7 @@ describe('Capture Record and Playback', function() {
   it('should record and playback calls matching `headers` option', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture-3';
+    const captureName = 'test-some-fancy-capture-3';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -355,7 +355,7 @@ describe('Capture Record and Playback', function() {
   it('should record and playback calls with empty `headers` option', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture-3';
+    const captureName = 'test-some-fancy-capture-3';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -431,7 +431,7 @@ describe('Capture Record and Playback', function() {
   it('should record and playback call with playAll', function(done) {
     this.timeout = 10000;
 
-    const captureName = 'some-fancy-capture-all';
+    const captureName = 'test-some-fancy-capture-all';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -443,7 +443,7 @@ describe('Capture Record and Playback', function() {
 
     // Mount remote service end points
     remote.get('/some/service/one', { text: 'first' });
-    remote.get('/some/service/two', { text: 'second' });
+    remote.get('/some/service/two', { json: { second: true } });
     remote.get('/some/service/three', { text: 'third' });
     remote.get('/some/service/four', { text: 'fourth' });
     remote.get('/some/service/five', { text: 'fifth' });
@@ -460,7 +460,7 @@ describe('Capture Record and Playback', function() {
         // Invoke requests to remote services through proxy
         // e.g. http://localhost:4041/http://example.com/some/service
         cb => proxyReq.get(path1).expect(200, 'first', cb),
-        cb => proxyReq.get(path2).expect(200, 'second', cb),
+        cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, 'fourth', cb),
         cb => proxyReq.get(path5).expect(200, 'fifth', cb),
@@ -505,7 +505,7 @@ describe('Capture Record and Playback', function() {
         // Assert remote url paths are routed the correct responses
         // e.g. http://localhost:4041/http://example.com/some/service
         cb => remoteReq.get(path1).expect(200, 'first', cb),
-        cb => remoteReq.get(path2).expect(200, 'second', cb),
+        cb => remoteReq.get(path2).expect(200, '{"second":true}', cb),
         cb => remoteReq.get(path3).expect(200, 'third', cb),
         cb => remoteReq.get(path4).expect(200, 'fourth', cb),
         cb => remoteReq.get(path5).expect(200, 'fifth', cb),
@@ -513,7 +513,7 @@ describe('Capture Record and Playback', function() {
         // Assert paths are routed the correct responses
         // e.g. http://localhost:4041/some/service
         cb => proxyReq.get(path1).expect(200, 'first', cb),
-        cb => proxyReq.get(path2).expect(200, 'second', cb),
+        cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, 'fourth', cb),
         cb => proxyReq.get(path5).expect(200, 'fifth', cb)

--- a/packages/mockyeah/test/unit/helpers.test.js
+++ b/packages/mockyeah/test/unit/helpers.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const { handleContentType } = require('../../app/lib/helpers');
+
+describe('app helpers', () => {
+  describe('handleContentType', () => {
+    it('gives raw with no content-type header', () => {
+      const body = 'some body';
+      const headers = {};
+      expect(handleContentType(body, headers)).to.deep.equal({
+        raw: body
+      });
+    });
+
+    it('gives raw with text content-type', () => {
+      const body = 'some body';
+      const headers = {
+        'content-type': 'text/plain'
+      };
+      expect(handleContentType(body, headers)).to.deep.equal({
+        raw: body
+      });
+    });
+
+    it('gives json with json content-type', () => {
+      const body = '{"foo":"bar"}';
+      const headers = {
+        'content-type': 'application/json'
+      };
+      expect(handleContentType(body, headers)).to.deep.equal({
+        json: {
+          foo: 'bar'
+        }
+      });
+    });
+  });
+});

--- a/packages/mockyeah/test/unit/helpers.test.js
+++ b/packages/mockyeah/test/unit/helpers.test.js
@@ -2,7 +2,11 @@
 
 const { expect } = require('chai');
 
-const { handleContentType } = require('../../app/lib/helpers');
+const {
+  handleContentType,
+  replaceFixtureWithRequireInJson,
+  getDataForRecordToFixtures
+} = require('../../app/lib/helpers');
 
 describe('app helpers', () => {
   describe('handleContentType', () => {
@@ -33,6 +37,56 @@ describe('app helpers', () => {
         json: {
           foo: 'bar'
         }
+      });
+    });
+  });
+
+  describe('replaceFixtureWithRequireInJson', () => {
+    it('replaces fixture as JSON file', () => {
+      const fixturePath = 'foo/1.json';
+      const json = `{
+        "fixture": "${fixturePath}"
+      }`;
+      const relativePath = '/my/path';
+      const result = replaceFixtureWithRequireInJson(json, {
+        relativePath
+      });
+      expect(result).to.equal(`{
+        "json": require("${relativePath}/${fixturePath}")
+      }`);
+    });
+  });
+
+  describe('getDataForRecordToFixtures', () => {
+    it('raw body is extracted and fixture option added', () => {
+      const raw = 'some raw response body';
+      const responseOptions = {
+        raw
+      };
+      const name = 'my-capture';
+      const index = 0;
+      const result = getDataForRecordToFixtures({ responseOptions, name, index });
+      expect(result).to.deep.equal({
+        newResponseOptions: {
+          fixture: `${name}/${index}.txt`
+        },
+        body: raw
+      });
+    });
+
+    it('JSON body is extracted and fixture option added', () => {
+      const json = { foo: 'bar' };
+      const responseOptions = {
+        json
+      };
+      const name = 'my-capture';
+      const index = 0;
+      const result = getDataForRecordToFixtures({ responseOptions, name, index });
+      expect(result).to.deep.equal({
+        newResponseOptions: {
+          fixture: `${name}/${index}.json`
+        },
+        body: '{\n  "foo": "bar"\n}'
       });
     });
   });

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -39,7 +39,7 @@ describe('prepareConfig', () => {
       proxy: false,
       record: false,
       verbose: false,
-      recordToFixtures: false,
+      recordToFixtures: true,
       recordToFixturesMode: 'path'
     });
   });
@@ -63,7 +63,7 @@ describe('prepareConfig', () => {
       proxy: false,
       record: false,
       verbose: false,
-      recordToFixtures: false,
+      recordToFixtures: true,
       recordToFixturesMode: 'path'
     });
   });

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -38,9 +38,12 @@ describe('prepareConfig', () => {
       port: 4001,
       proxy: false,
       record: false,
-      verbose: false
+      verbose: false,
+      recordToFixtures: false,
+      recordToFixturesMode: 'path'
     });
   });
+
   it('should work and use defaults with empty config input', () => {
     const config = prepareConfig({});
     expect(config).to.deep.equal({
@@ -59,7 +62,9 @@ describe('prepareConfig', () => {
       port: 4001,
       proxy: false,
       record: false,
-      verbose: false
+      verbose: false,
+      recordToFixtures: false,
+      recordToFixturesMode: 'path'
     });
   });
 });


### PR DESCRIPTION
This adds support for recording to put response bodies into fixture files rather than inline them into the capture files. This makes the files smaller, lighter on editors, and easier to work with and reuse for other non-capture purposes (e.g., unit tests). This can be enabled with a config value `recordToFixture === true`. We support both the `fixture` option where a fixture file path is used in the capture response options (works for `raw` as `.txt` files and JSON files), and also support the `json` option where an inline `require` call is used, enabled with config option `recordToFixturesMode === 'require'`.

~Pending documentation, which I could add in another PR.~ Added documentation.

Includes changes from #199 that were somewhat needed to deserialize JSON responses as objects in order to detect the response type (could later refactor to rely only on `content-type` header and maybe use a MIME type library to lookup appropriate file name extensions to be used for the fixtures). This will mean that even if you don't use `recordToFixtures`, we'll still nicely format any JSON responses inline in the capture files using the `json` key instead of `raw` with a serialized, unformatted string. Perhaps in the future we should allow this to be controlled by an option in case anyone really cares to retain the formatting of the original JSON.

Closes #199.
