### PR TITLE
feat: opt-in flags to record headers and latency

### DIFF
--- a/docs/book/CLI/CLI.md
+++ b/docs/book/CLI/CLI.md
@@ -50,6 +50,7 @@ Good work! You've recorded and played back a service snapshot.
 
 ```console
 $ mockyeah --help
+
 Usage: mockyeah [options] [command]
 
   Commands:
@@ -70,12 +71,15 @@ For help with specific commands, you can pass `--help` to them, e.g.:
 
 ```console
 $ mockyeah record --help
+
 Usage: mockyeah-record [options]
 
   Options:
 
-    -h, --help           output usage information
     -o, --only <regex>   only record calls to URLs matching given regex pattern
-    -h, --header <line>  record matches will require these headers ("Name: Value")
+    -h, --use-headers    record headers to response options
+    -l, --use-latency    record latency to response options
+    -H, --header <line>  record matches will require these headers ("Name: Value") (default: [object Object])
     -v, --verbose        verbose output
+    -h, --help           output usage information
 ```

--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -24,6 +24,8 @@ const collect = (val, memo) => {
 
 program
   .option('-o, --only <regex>', 'only record calls to URLs matching given regex pattern')
+  .option('-h, --use-headers', 'record headers to response options')
+  .option('-l, --use-latency', 'record latency to response options')
   .option(
     '-H, --header <line>',
     'record matches will require these headers ("Name: Value")',
@@ -83,13 +85,15 @@ global.MOCKYEAH_VERBOSE_OUTPUT = Boolean(program.verbose);
 
 boot(env => {
   const [name] = program.args;
-  const { only, header } = program;
+  const { only, header, useHeaders, useLatency } = program;
 
   env.program = program;
 
   const options = {
     only,
-    headers: header
+    headers: header,
+    useHeaders,
+    useLatency
   };
 
   if (!name) {

--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -69,7 +69,7 @@ const proxyRoute = (req, res, next) => {
 
     if (!app.locals.recording) return;
 
-    const { only } = recordMeta;
+    const { only, useHeaders, useLatency } = recordMeta;
 
     if (only && !only(reqUrl)) return;
 
@@ -105,16 +105,22 @@ const proxyRoute = (req, res, next) => {
     // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
     delete headers['transfer-encoding'];
 
-    const options = Object.assign(
+    const responseOptions = Object.assign(
       {
-        headers,
-        status,
-        latency
+        status
       },
       handleContentType(_body, headers)
     );
 
-    recordMeta.set.push([match, options]);
+    if (useHeaders) {
+      responseOptions.headers = headers;
+    }
+
+    if (useLatency) {
+      responseOptions.latency = latency;
+    }
+
+    recordMeta.set.push([match, responseOptions]);
   }).pipe(res);
 };
 

--- a/packages/mockyeah/app/recorder.js
+++ b/packages/mockyeah/app/recorder.js
@@ -14,13 +14,15 @@ module.exports = app => (name, options = {}) => {
     app.log(['serve', 'record', 'only'], regex);
   }
 
-  const { headers } = options;
+  const { headers, useHeaders, useLatency } = options;
 
   app.locals.recordMeta = {
     headers,
     name,
     options,
     only,
+    useHeaders,
+    useLatency,
     set: []
   };
 


### PR DESCRIPTION
This add features for flags `--use-headers` (or `-h`) and `--use-latency` (or `-l`) that will opt-in to recording headers and latency to capture files. By default, we will now not record these, because they are usually not very useful and just add noise.

I did not add unit tests at this time since we don't have a good framework for testing recording with various combinations of options, but I am ideating on how to achieve that soon and will follow up with such a PR once complete.

BREAKING CHANGE: headers and latency not recorded by default

Fixes #204
