### PR TITLE
fix: encode urls

### DIFF
--- a/packages/mockyeah/app/lib/constants.js
+++ b/packages/mockyeah/app/lib/constants.js
@@ -1,0 +1,9 @@
+const decodedPortRegex = /^(\/?https?.{3}[^/:?]+):/;
+const decodedProtocolRegex = /^(\/?https?).{3}/;
+const encodedPortRegex = /^(\/?https?.{3}[^/:?]+)~/;
+const encodedProtocolRegex = /^(\/?https?).{3}/;
+
+exports.decodedPortRegex = decodedPortRegex;
+exports.decodedProtocolRegex = decodedProtocolRegex;
+exports.encodedPortRegex = encodedPortRegex;
+exports.encodedProtocolRegex = encodedProtocolRegex;

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -1,5 +1,12 @@
 const path = require('path');
 
+const {
+  decodedPortRegex,
+  decodedProtocolRegex,
+  encodedPortRegex,
+  encodedProtocolRegex
+} = require('./constants');
+
 function resolveFilePath(capturePath, url) {
   const fileName = url.replace(/\//g, '|');
   return path.resolve(capturePath, fileName);
@@ -58,6 +65,15 @@ const getDataForRecordToFixtures = ({ responseOptions, name, index }) => {
   };
 };
 
+// Restore any special protocol or port characters that were possibly tilde-replaced.
+const decodeProtocolAndPort = str =>
+  str.replace(encodedProtocolRegex, '$1://').replace(encodedPortRegex, '$1:');
+
+const encodeProtocolAndPort = str =>
+  str.replace(decodedPortRegex, '$1~').replace(decodedProtocolRegex, '$1~~~');
+
+exports.decodeProtocolAndPort = decodeProtocolAndPort;
+exports.encodeProtocolAndPort = encodeProtocolAndPort;
 exports.getDataForRecordToFixtures = getDataForRecordToFixtures;
 exports.replaceFixtureWithRequireInJson = replaceFixtureWithRequireInJson;
 exports.handleContentType = handleContentType;

--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -1,17 +1,19 @@
 const request = require('request');
 const isAbsoluteUrl = require('is-absolute-url');
 const { isEmpty } = require('lodash');
-const { handleContentType } = require('./lib/helpers');
+const { decodeProtocolAndPort, handleContentType } = require('./lib/helpers');
 
 const now = () => new Date().getTime();
 
 const openingSlashRegex = /^\//;
-const leadProtocolRegex = /^(https?)%3A%2F%2F/;
+const leadUrlEncodedProtocolRegex = /^(https?)%3A%2F%2F/;
 
 const makeRequestUrl = req =>
-  req.originalUrl
-    .replace(openingSlashRegex, '')
-    .replace(leadProtocolRegex, (match, p1) => `${p1}://`);
+  decodeProtocolAndPort(
+    req.originalUrl
+      .replace(openingSlashRegex, '')
+      .replace(leadUrlEncodedProtocolRegex, (match, p1) => `${p1}://`)
+  );
 
 const makeRequestOptions = req => {
   const { headers: _headers, method: _method } = req;

--- a/packages/mockyeah/test/integration/RouteProxyMethodTest.js
+++ b/packages/mockyeah/test/integration/RouteProxyMethodTest.js
@@ -94,6 +94,27 @@ describe('Route proxy method', () => {
     );
   });
 
+  describe('custom-encoded URLs', () => {
+    it('should support registering full URLs and matching request with custom-encoded URLs', done => {
+      mockyeah.get(`/http://localhost:${proxiedPort}/foo?ok=yes`, { text: 'bar', status: 500 });
+
+      async.series(
+        [
+          cb =>
+            supertest(proxiedApp)
+              .get('/foo')
+              .expect(200, cb),
+          cb => request.get(`/http~~~localhost~${proxiedPort}/foo?ok=yes`).expect(500, 'bar', cb)
+        ],
+        done
+      );
+    });
+
+    it('should support proxying custom-encoded URLs', done => {
+      request.get(`/http~~~localhost~${proxiedPort}/foo`).expect(200, done);
+    });
+  });
+
   it('should support proxying other URLs', done => {
     request.get(`/http://localhost:${proxiedPort}/foo?ok=yes`).expect(200, done);
   });


### PR DESCRIPTION
We'll encode the URLs with URL-safe characters (`~` tildes) before compiling the path regex so colons in protocol and port aren't confused with Express parameters. This will also support allowing proxying and recording with encoded incoming URLs, which may help in some infrastructures where protocol or port character sequences like `://` and `:` in the path cause problems, e.g., if the `//` is converted to `/` by some other application or proxy layer.