### PR TITLE
feat: add formatScript config for recorded captures

### DIFF
--- a/docs/book/Configuration.md
+++ b/docs/book/Configuration.md
@@ -17,8 +17,11 @@
   "adminServer": true,
   "adminHost": "localhost",
   "adminPort": 4777,
+  "httpsCertPath": undefined,
+  "httpsKeyPath": undefined,
   "recordToFixtures": true,
-  "recordToFixturesMode": "path"
+  "recordToFixturesMode": "path",
+  "formatScript": undefined
 }
 ```
 
@@ -89,6 +92,7 @@ Internally, this mounts with a leading slash, i.e., `'/https://service.example.c
 - `recordToFixturesMode`: When `recordToFixtures` is enabled, which mode to use to refer to fixture files
   - "path" (default): Use the response option of `fixture` with the path to the fixture file as a string.
   - "require": For JSON fixtures, use the response option of `json` with an inline `require` of the JSON file using a relative path, otherwise fallback to "path" mode (may support custom `require`-able files in the future for users with custom setups, e.g., Webpack loaders).
+- `formatScript`: To apply custom formatting to the JS in the capture files, specify a string path to a module (relative to mockyeah root near your config file) that exports a function of the signature `(js: string) : string => {}`. Or if using programatically rather than a JSON config file, you can provide a function as a value directly.
 
 ### HTTPS
 

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -19,7 +19,8 @@ const configDefaults = {
   adminHost: 'localhost',
   adminPort: 4777,
   recordToFixtures: true,
-  recordToFixturesMode: 'path'
+  recordToFixturesMode: 'path',
+  formatScript: undefined
 };
 
 module.exports = (config = {}) => {

--- a/packages/mockyeah/test/formatter.js
+++ b/packages/mockyeah/test/formatter.js
@@ -1,0 +1,1 @@
+module.exports = js => js.replace(/[\s\n\r]/g, ' ');

--- a/packages/mockyeah/test/integration/CaptureRecordFormatScriptFileTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordFormatScriptFileTest.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/* eslint-disable no-sync */
+
+const fs = require('fs');
+const path = require('path');
+const async = require('async');
+const supertest = require('supertest');
+const rimraf = require('rimraf');
+const MockYeahServer = require('../../server');
+const { expect } = require('chai');
+
+const PROXY_CAPTURES_DIR = path.resolve(__dirname, '../.tmp/proxy/mockyeah');
+
+describe('Capture Record Format Script File Test', function() {
+  let proxy;
+  let remote;
+  let proxyReq;
+  let remoteReq;
+
+  before(done => {
+    async.parallel(
+      [
+        function(cb) {
+          // Instantiate proxy server for recording
+          proxy = MockYeahServer(
+            {
+              name: 'proxy',
+              port: 0,
+              adminPort: 0,
+              capturesDir: PROXY_CAPTURES_DIR,
+              formatScript: path.resolve(__dirname, '../formatter.js')
+            },
+            cb
+          );
+        },
+        function(cb) {
+          // Instantiate remote server
+          remote = MockYeahServer(
+            {
+              name: 'remote',
+              port: 0,
+              adminPort: 0
+            },
+            cb
+          );
+        }
+      ],
+      () => {
+        remoteReq = supertest(remote.server);
+        proxyReq = supertest(`${proxy.server.rootUrl}/${remote.server.rootUrl}`);
+        done();
+      }
+    );
+  });
+
+  afterEach(() => {
+    proxy.reset();
+    remote.reset();
+    rimraf.sync(PROXY_CAPTURES_DIR);
+  });
+
+  after(() => {
+    proxy.close();
+    remote.close();
+  });
+
+  function getCaptureFilePath(captureName) {
+    return path.resolve(PROXY_CAPTURES_DIR, captureName, 'index.js');
+  }
+
+  it('should record and format script', function(done) {
+    this.timeout = 10000;
+
+    const captureName = 'test-some-fancy-capture-using-latency';
+
+    // Construct remote service urls
+    // e.g. http://localhost:4041/http://example.com/some/service
+    const path1 = '/some/service/one';
+
+    // Mount remote service end points
+    remote.get('/some/service/one', {});
+
+    // Initiate recording and playback series
+    async.series(
+      [
+        // Initiate recording
+        cb => {
+          proxy.record(captureName);
+          cb();
+        },
+
+        // Invoke requests to remote services through proxy
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => proxyReq.get(path1).expect(200, cb),
+
+        // Stop recording
+        cb => {
+          proxy.recordStop(cb);
+        },
+
+        // Assert capture file exists
+        cb => {
+          const contents = fs.readFileSync(getCaptureFilePath(captureName), 'utf8');
+          expect(contents).to.match(
+            // eslint-disable-next-line no-regex-spaces
+            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "status": 200,       "raw": ""     }   \] ];/
+          );
+          cb();
+        },
+
+        // Reset proxy services and play captured capture
+        cb => {
+          proxy.reset();
+          cb();
+        },
+
+        cb => {
+          proxy.play(captureName);
+          cb();
+        },
+
+        // Test remote url paths and their sub paths route to the same services
+        // Assert remote url paths are routed the correct responses
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => remoteReq.get(path1).expect(200, cb),
+
+        // Assert paths are routed the correct responses
+        cb => proxyReq.get(path1).expect(200, cb)
+      ],
+      done
+    );
+  });
+});

--- a/packages/mockyeah/test/integration/CaptureRecordFormatScriptFunctionTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordFormatScriptFunctionTest.js
@@ -1,0 +1,135 @@
+'use strict';
+
+/* eslint-disable no-sync */
+
+const fs = require('fs');
+const path = require('path');
+const async = require('async');
+const supertest = require('supertest');
+const rimraf = require('rimraf');
+const MockYeahServer = require('../../server');
+const { expect } = require('chai');
+const formatScript = require('../formatter');
+
+const PROXY_CAPTURES_DIR = path.resolve(__dirname, '../.tmp/proxy/mockyeah');
+
+describe('Capture Record Format Script Function Test', function() {
+  let proxy;
+  let remote;
+  let proxyReq;
+  let remoteReq;
+
+  before(done => {
+    async.parallel(
+      [
+        function(cb) {
+          // Instantiate proxy server for recording
+          proxy = MockYeahServer(
+            {
+              name: 'proxy',
+              port: 0,
+              adminPort: 0,
+              capturesDir: PROXY_CAPTURES_DIR,
+              formatScript
+            },
+            cb
+          );
+        },
+        function(cb) {
+          // Instantiate remote server
+          remote = MockYeahServer(
+            {
+              name: 'remote',
+              port: 0,
+              adminPort: 0
+            },
+            cb
+          );
+        }
+      ],
+      () => {
+        remoteReq = supertest(remote.server);
+        proxyReq = supertest(`${proxy.server.rootUrl}/${remote.server.rootUrl}`);
+        done();
+      }
+    );
+  });
+
+  afterEach(() => {
+    proxy.reset();
+    remote.reset();
+    rimraf.sync(PROXY_CAPTURES_DIR);
+  });
+
+  after(() => {
+    proxy.close();
+    remote.close();
+  });
+
+  function getCaptureFilePath(captureName) {
+    return path.resolve(PROXY_CAPTURES_DIR, captureName, 'index.js');
+  }
+
+  it('should record and format script', function(done) {
+    this.timeout = 10000;
+
+    const captureName = 'test-some-fancy-capture-using-latency';
+
+    // Construct remote service urls
+    // e.g. http://localhost:4041/http://example.com/some/service
+    const path1 = '/some/service/one';
+
+    // Mount remote service end points
+    remote.get('/some/service/one', {});
+
+    // Initiate recording and playback series
+    async.series(
+      [
+        // Initiate recording
+        cb => {
+          proxy.record(captureName);
+          cb();
+        },
+
+        // Invoke requests to remote services through proxy
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => proxyReq.get(path1).expect(200, cb),
+
+        // Stop recording
+        cb => {
+          proxy.recordStop(cb);
+        },
+
+        // Assert capture file exists
+        cb => {
+          const contents = fs.readFileSync(getCaptureFilePath(captureName), 'utf8');
+          expect(contents).to.match(
+            // eslint-disable-next-line no-regex-spaces
+            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "status": 200,       "raw": ""     }   \] ];/
+          );
+          cb();
+        },
+
+        // Reset proxy services and play captured capture
+        cb => {
+          proxy.reset();
+          cb();
+        },
+
+        cb => {
+          proxy.play(captureName);
+          cb();
+        },
+
+        // Test remote url paths and their sub paths route to the same services
+        // Assert remote url paths are routed the correct responses
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => remoteReq.get(path1).expect(200, cb),
+
+        // Assert paths are routed the correct responses
+        cb => proxyReq.get(path1).expect(200, cb)
+      ],
+      done
+    );
+  });
+});

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -40,7 +40,8 @@ describe('prepareConfig', () => {
       record: false,
       verbose: false,
       recordToFixtures: true,
-      recordToFixturesMode: 'path'
+      recordToFixturesMode: 'path',
+      formatScript: undefined
     });
   });
 


### PR DESCRIPTION
Adds feature to configure mockyeah to use a custom script to format the recorded capture JS files.

To apply custom formatting to the JS in the capture files, use `formatScript` in the config to specify a string path to a module (relative to mockyeah root near your config file) that exports a function of the signature `(js: string) : string => {}`. Or if using programatically rather than a JSON config file, you can provide a function as a value directly.

Fixes #200.
