### PR TITLE
fix: format whole js script

### DIFF
--- a/packages/mockyeah/app/recordStopper.js
+++ b/packages/mockyeah/app/recordStopper.js
@@ -71,6 +71,8 @@ module.exports = app => cb => {
     });
   }
 
+  let jsModule = `module.exports = ${js};`;
+
   if (formatScript) {
     let formatFunction;
 
@@ -83,11 +85,9 @@ module.exports = app => cb => {
     }
 
     if (formatFunction) {
-      js = formatFunction(js);
+      jsModule = formatFunction(jsModule);
     }
   }
-
-  const jsModule = `module.exports = ${js};`;
 
   fs.writeFile(filePath, jsModule, err => {
     if (err) {


### PR DESCRIPTION
We should've been passing the whole script file into the format function, not just the piece assigned to `module.exports`.