### PR TITLE
fix: decode urls for regex & func match

### DIFF
--- a/packages/mockyeah/app/lib/RouteResolver.js
+++ b/packages/mockyeah/app/lib/RouteResolver.js
@@ -176,7 +176,7 @@ const handlePathTypes = (_path, _query) => {
 
     return {
       path: _path,
-      pathFn: p => _path.test(p),
+      pathFn: p => _path.test(decodeProtocolAndPort(p)),
       pathname: _path
     };
   }
@@ -184,7 +184,7 @@ const handlePathTypes = (_path, _query) => {
   if (typeof _path === 'function') {
     return {
       path: _path,
-      pathFn: _path,
+      pathFn: p => _path(decodeProtocolAndPort(p)),
       pathname: _path
     };
   }

--- a/packages/mockyeah/test/integration/RouteProxyMethodTest.js
+++ b/packages/mockyeah/test/integration/RouteProxyMethodTest.js
@@ -110,6 +110,39 @@ describe('Route proxy method', () => {
       );
     });
 
+    it('should support registering full URLs and matching request with custom-encoded URLs with regex', done => {
+      mockyeah.get(new RegExp(`http:\/\/localhost:${proxiedPort}`), { text: 'bar', status: 500 });
+
+      async.series(
+        [
+          cb =>
+            supertest(proxiedApp)
+              .get('/foo')
+              .expect(200, cb),
+          cb => request.get(`/http~~~localhost~${proxiedPort}/foo?ok=yes`).expect(500, 'bar', cb)
+        ],
+        done
+      );
+    });
+
+    it('should support registering full URLs and matching request with custom-encoded URLs with function', done => {
+      mockyeah.get(p => p === `/http://localhost:${proxiedPort}/foo`, {
+        text: 'bar',
+        status: 500
+      });
+
+      async.series(
+        [
+          cb =>
+            supertest(proxiedApp)
+              .get('/foo')
+              .expect(200, cb),
+          cb => request.get(`/http~~~localhost~${proxiedPort}/foo?ok=yes`).expect(500, 'bar', cb)
+        ],
+        done
+      );
+    });
+
     it('should support proxying custom-encoded URLs', done => {
       request.get(`/http~~~localhost~${proxiedPort}/foo`).expect(200, done);
     });


### PR DESCRIPTION
Fixes a regression with URL encoding where regex and function matches weren't being decoded.