### PR TITLE
feat: expectation.verify supports callback

### DIFF
--- a/docs/book/API/Expectation-API.md
+++ b/docs/book/API/Expectation-API.md
@@ -21,8 +21,7 @@ describe("This test", () => {
     request("http://localhost:4040")
       .get("/say-hello?foo=bar")
       .expect(200, () => {
-        expectation.verify();
-        done();
+        expectation.verify(done);
       });
   });
 });
@@ -87,7 +86,7 @@ const expectation = mockyeah
 ```
 
 <div id="verify"></div>
-`.verify()` - Asserts expectation to be correct.
+`.verify(callback)` - Asserts expectation to be correct, and if optional callback is provided, using that to pass up assertion errors instead of throwing inline.
 
 ```js
 expectation.verify();

--- a/docs/book/Getting-Started.md
+++ b/docs/book/Getting-Started.md
@@ -99,8 +99,7 @@ describe('Wondrous service', () => {
       .get('/wondrous?foo=bar')
       .expect(200, 'it worked')
       .then(() => {
-        expectation.verify();
-        done();
+        expectation.verify(done);
       });
   });
 });

--- a/packages/mockyeah/app/lib/Expectation.js
+++ b/packages/mockyeah/app/lib/Expectation.js
@@ -165,8 +165,19 @@ Expectation.prototype.api = function api() {
       });
       return this;
     },
-    verify: function verify() {
-      internal.assertions.forEach(_assertion => _assertion());
+    verify: function verify(callback) {
+      try {
+        internal.assertions.forEach(_assertion => _assertion());
+        if (callback) {
+          callback();
+        }
+      } catch (err) {
+        if (callback) {
+          callback(err);
+        } else {
+          throw err;
+        }
+      }
     }
   };
 };

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -431,6 +431,49 @@ describe('Route expectation', () => {
     );
   });
 
+  it('should support expectation callback', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .header('host', 'example.com')
+      .params({
+        id: '9999'
+      })
+      .body({
+        foo: 'bar'
+      })
+      .once();
+
+    request
+      .post('/foo?id=9999')
+      .set('HOST', 'example.com')
+      .send({ foo: 'bar' })
+      .end(() => {
+        expectation.verify(done);
+      });
+  });
+
+  it('should support expectation callback with error', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .header('host', 'example.com')
+      .params({
+        id: '9999'
+      })
+      .body({
+        foo: 'bar'
+      })
+      .once();
+
+    request.post('/foo?id=9999').end(() => {
+      expectation.verify(err => {
+        expect(err).to.exist;
+        done();
+      });
+    });
+  });
+
   it('should allow composable expectations', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -468,6 +468,7 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
+        // eslint-disable-next-line no-unused-expressions
         expect(err).to.exist;
         done();
       });


### PR DESCRIPTION
Adds support for `expectation.verify` to optionally accept a callback to which it can pass `err` if any in traditional Node style, rather than throwing assertion errors inline. This makes integration with many testing frameworks' async support, such as `mocha` or `jest` with `done` callbacks, much easier.

Fixes #134 
