### PR TITLE
feat: handle error thrown in expect function

### DIFF
--- a/docs/book/API/Expectation-API.md
+++ b/docs/book/API/Expectation-API.md
@@ -94,7 +94,7 @@ expectation.verify();
 
 The `body`, `params`, and `header` methods also accept a function instead of an object, for custom validations.
 These functions receive as a first parameter the parsed body, query parameters object, or header value, respectively,
-and should return `true` or `false` to indicate a pass or failure of the expectation.
+and should return `true` to indicate a pass, or return `false` or throw an error (like many assertion libraries) to indicate a failure.
 
 Examples:
 
@@ -103,6 +103,19 @@ const expectation = mockyeah
   .get("/foo", { text: "bar" })
   .expect()
   .header("X-API-Key", value => /[0-9A-F]{32}/i.test(value));
+```
+
+```js
+const { expect } = require("chai");
+
+const expectation = mockyeah
+  .get("/foo", { text: "bar" })
+  .expect()
+  .params(params =>
+    expect(params).to.equal({
+      some: "value"
+    })
+  );
 ```
 
 ```js

--- a/packages/mockyeah/app/lib/Expectation.js
+++ b/packages/mockyeah/app/lib/Expectation.js
@@ -31,7 +31,7 @@ const assertion = function assertion(value, actualValue, message) {
       assert(result, message);
     }
   } catch (err) {
-    assert(false, message);
+    assert(false, message + (err && err.message ? `: ${err.message}` : ''));
   }
 };
 

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -475,6 +475,54 @@ describe('Route expectation', () => {
     });
   });
 
+  it('should handle custom error in expectation functions', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .params(params => {
+        expect(params).to.equal({
+          id: '9999'
+        });
+      })
+      .once();
+
+    request.post('/foo?id=9999').end(() => {
+      expectation.verify(err => {
+        try {
+          expect(err.message).to.equal(
+            "[post] /foo -- Params did not match expectation callback: expected { id: '9999' } to equal { id: '9999' }"
+          );
+          done();
+        } catch (err2) {
+          done(err2);
+        }
+      });
+    });
+  });
+
+  it('should render custom error in expectation functions', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .params(() => {
+        throw new Error('my custom assertion error');
+      })
+      .once();
+
+    request.post('/foo?id=9999').end(() => {
+      expectation.verify(err => {
+        try {
+          expect(err.message).to.equal(
+            '[post] /foo -- Params did not match expectation callback: my custom assertion error'
+          );
+          done();
+        } catch (err2) {
+          done(err2);
+        }
+      });
+    });
+  });
+
   it('should allow composable expectations', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })


### PR DESCRIPTION
Better handling of errors thrown in custom expect function. Rather than obscuring the underlying cause, we now include the thrown error's message in the mockyeah assertion error message, which is logged to the user. We also update the line in the documentation to reveal this functionality.

Fixes #136