### PR TITLE
feat: custom expect function with all data

### DIFF
--- a/docs/book/API/Expectation-API.md
+++ b/docs/book/API/Expectation-API.md
@@ -29,7 +29,15 @@ describe("This test", () => {
 
 <div id="expect"></div>
 
-`.expect()` - Returns an expectation object for a given mock service when chained to a [Mock Services API](./Mock-API.md) method call.
+`.expect(optionalPredicate)` - Returns an expectation object for a given mock service when chained to a [Mock Services API](./Mock-API.md) method call. If provided an optional predicate function, it will call this function on `.verify()`
+where we can throw errors or return true/false to make assertions.
+It receives one argument - an object with the following fields:
+
+- `path` (String): the request path.
+- `query` (Object): a key/value map of query parameters.
+- `headers` (Object): a key/value map of headers. Header names are all lowercase.
+- `body` (Object|String): the parsed response body. If JSON, then a JS objec, otherwise a string.
+- `req` (Object): the raw Express request object for additional custom assertions.
 
 <div id="atLeast">
 
@@ -91,7 +99,7 @@ const expectation = mockyeah
 
 <div id="header"></div>
 
-`.header(Key, Value)` - Adds expectation that a service must receive only requests with headers matching those specified.
+`.header(key, value)` - Adds expectation that a service must receive only requests with headers matching those specified.
 
 ```js
 const expectation = mockyeah

--- a/packages/mockyeah/app/lib/Expectation.js
+++ b/packages/mockyeah/app/lib/Expectation.js
@@ -41,10 +41,11 @@ Expectation.prototype.api = function api(predicate) {
   if (predicate) {
     internal.handlers.push(req => {
       try {
-        const { headers, query, body } = req;
+        const { headers, query, body, _parsedUrl } = req;
+        const { pathname: path } = _parsedUrl;
 
         const result = predicate({
-          path: req._parsedUrl.pathname,
+          path,
           query,
           headers,
           body,
@@ -55,9 +56,9 @@ Expectation.prototype.api = function api(predicate) {
           throw new Error('function returned false');
         }
       } catch (err) {
-        const message =
-          `${internal.prefix} Expect function did not match` +
-          (err && err.message ? `: ${err.message}` : '');
+        const message = `${internal.prefix} Expect function did not match${
+          err && err.message ? `: ${err.message}` : ''
+        }`;
         assert(false, message);
       }
     });

--- a/packages/mockyeah/app/lib/Expectation.js
+++ b/packages/mockyeah/app/lib/Expectation.js
@@ -35,8 +35,34 @@ const assertion = function assertion(value, actualValue, message) {
   }
 };
 
-Expectation.prototype.api = function api() {
+Expectation.prototype.api = function api(predicate) {
   const internal = this;
+
+  if (predicate) {
+    internal.handlers.push(req => {
+      try {
+        const { headers, query, body } = req;
+
+        const result = predicate({
+          path: req._parsedUrl.pathname,
+          query,
+          headers,
+          body,
+          req
+        });
+
+        if (typeof result !== 'undefined' && !result) {
+          throw new Error('function returned false');
+        }
+      } catch (err) {
+        const message =
+          `${internal.prefix} Expect function did not match` +
+          (err && err.message ? `: ${err.message}` : '');
+        assert(false, message);
+      }
+    });
+  }
+
   return {
     atLeast: function atLeast(number) {
       internal.assertions.push(() => {

--- a/packages/mockyeah/app/lib/RouteResolver.js
+++ b/packages/mockyeah/app/lib/RouteResolver.js
@@ -223,7 +223,7 @@ RouteResolver.prototype.register = function register(method, _path, response) {
   this.routes.push(route);
 
   return {
-    expect: () => expectation.api()
+    expect: predicate => expectation.api(predicate)
   };
 };
 

--- a/packages/mockyeah/eslint.config.js
+++ b/packages/mockyeah/eslint.config.js
@@ -1,16 +1,13 @@
 const tools = require('tools/eslint.config.js');
 
-module.exports = Object.assign(
-  {},
-  tools,
-  {
-    overrides: [
-      {
-        files: ['test/**/*.js'],
-        rules: {
-          'func-names': 0
-        }
+module.exports = Object.assign({}, tools, {
+  overrides: [
+    {
+      files: ['test/**/*.js'],
+      rules: {
+        'func-names': 0,
+        'no-unused-expressions': 0
       }
-    ]
-  }
-);
+    }
+  ]
+});

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -670,9 +670,7 @@ describe('Route expectation', () => {
   it('should support custom generic expect handler returning true', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })
-      .expect(data => {
-        return data.path === '/foo';
-      })
+      .expect(data => data.path === '/foo')
       .once();
 
     request
@@ -687,9 +685,7 @@ describe('Route expectation', () => {
   it('should render custom error in expectation functions returning false', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })
-      .expect(data => {
-        return data.path === '/what';
-      })
+      .expect(data => data.path === '/what')
       .once();
 
     request.post('/foo?id=9999').end(() => {

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -610,4 +610,121 @@ describe('Route expectation', () => {
         expectation.verify(done);
       });
   });
+
+  it('should support custom generic expect handler', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect(data => {
+        expect(data).to.exist;
+
+        expect(data.headers).to.be.object;
+        expect(data.query).to.be.object;
+        expect(data.body).to.be.object;
+        expect(data.req).to.be.object;
+
+        expect(data.path).to.equal('/foo');
+        expect(data.query.id).to.equal('9999');
+        expect(data.headers.host).to.equal('example.com');
+        expect(data.body.foo).to.equal('bar');
+        expect(data.req.originalUrl).to.equal('/foo?id=9999');
+      })
+      .once();
+
+    request
+      .post('/foo?id=9999')
+      .set('HOST', 'example.com')
+      .send({ foo: 'bar' })
+      .end(() => {
+        expectation.verify(done);
+      });
+  });
+
+  it('should support custom generic expect handler', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect(data => {
+        expect(data).to.exist;
+
+        expect(data.headers).to.be.object;
+        expect(data.query).to.be.object;
+        expect(data.body).to.be.object;
+        expect(data.req).to.be.object;
+
+        expect(data.path).to.equal('/foo');
+        expect(data.query.id).to.equal('9999');
+        expect(data.headers.host).to.equal('example.com');
+        expect(data.body.foo).to.equal('bar');
+        expect(data.req.originalUrl).to.equal('/foo?id=9999');
+      })
+      .once();
+
+    request
+      .post('/foo?id=9999')
+      .set('HOST', 'example.com')
+      .send({ foo: 'bar' })
+      .end(() => {
+        expectation.verify(done);
+      });
+  });
+
+  it('should support custom generic expect handler returning true', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect(data => {
+        return data.path === '/foo';
+      })
+      .once();
+
+    request
+      .post('/foo?id=9999')
+      .set('HOST', 'example.com')
+      .send({ foo: 'bar' })
+      .end(() => {
+        expectation.verify(done);
+      });
+  });
+
+  it('should render custom error in expectation functions returning false', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect(data => {
+        return data.path === '/what';
+      })
+      .once();
+
+    request.post('/foo?id=9999').end(() => {
+      expectation.verify(err => {
+        try {
+          expect(err.message).to.equal(
+            '[post] /foo -- Expect function did not match: function returned false'
+          );
+          done();
+        } catch (err2) {
+          done(err2);
+        }
+      });
+    });
+  });
+
+  it('should render custom error in expectation functions with error', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect(() => {
+        throw new Error('my custom assertion error');
+      })
+      .once();
+
+    request.post('/foo?id=9999').end(() => {
+      expectation.verify(err => {
+        try {
+          expect(err.message).to.equal(
+            '[post] /foo -- Expect function did not match: my custom assertion error'
+          );
+          done();
+        } catch (err2) {
+          done(err2);
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds a feature for `.expect` to take an optional predicate function which is added as an assertion. It receives all the metadata it needs (path, query, headers, body, and raw request object), and can throw exceptions or return true/false to make assertions. This way, it's easier to make generic assertions, or assert on combinations of different fields.

Fixes #135.
