### PR TITLE
fix: expect method functions boolean return & throws

### DIFF
--- a/packages/mockyeah/app/lib/Expectation.js
+++ b/packages/mockyeah/app/lib/Expectation.js
@@ -24,14 +24,18 @@ Expectation.prototype.middleware = function middleware(req, res, next) {
   next();
 };
 
-const assertion = function assertion(value, actualValue, message) {
+const assertion = function assertion(fn, actualValue, message) {
+  let result;
+
   try {
-    const result = value(actualValue);
-    if (result !== undefined) {
-      assert(result, message);
-    }
+    result = fn(actualValue);
   } catch (err) {
     assert(false, message + (err && err.message ? `: ${err.message}` : ''));
+    return;
+  }
+
+  if (result !== undefined && !result) {
+    assert(false, `${message}: function returned false`);
   }
 };
 

--- a/packages/mockyeah/app/lib/Expectation.js
+++ b/packages/mockyeah/app/lib/Expectation.js
@@ -31,11 +31,10 @@ const assertion = function assertion(fn, actualValue, message) {
     result = fn(actualValue);
   } catch (err) {
     assert(false, message + (err && err.message ? `: ${err.message}` : ''));
-    return;
   }
 
-  if (result !== undefined && !result) {
-    assert(false, `${message}: function returned false`);
+  if (result !== undefined) {
+    assert(result, `${message}: function returned false`);
   }
 };
 

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -480,17 +480,18 @@ describe('Route expectation', () => {
       .post('/foo', { text: 'bar' })
       .expect()
       .params(params => {
-        expect(params).to.equal({
-          id: '9999'
+        expect(params).to.deep.equal({
+          id: '1234'
         });
       })
       .once();
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
+        if (!err) return done(new Error('expected error'));
         try {
           expect(err.message).to.equal(
-            "[post] /foo -- Params did not match expectation callback: expected { id: '9999' } to equal { id: '9999' }"
+            "[post] /foo -- Params did not match expectation callback: expected { id: '9999' } to deeply equal { id: '1234' }"
           );
           done();
         } catch (err2) {
@@ -511,6 +512,7 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
+        if (!err) return done(new Error('expected error'));
         try {
           expect(err.message).to.equal(
             '[post] /foo -- Params did not match expectation callback: my custom assertion error'
@@ -535,6 +537,7 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
+        if (!err) return done(new Error('expected error'));
         try {
           expect(err.message).to.equal('[post] /foo -- Params did not match expectation callback');
           done();
@@ -557,8 +560,43 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
+        if (!err) return done(new Error('expected error'));
         try {
           expect(err.message).to.equal('[post] /foo -- Params did not match expectation callback');
+          done();
+        } catch (err2) {
+          done(err2);
+        }
+      });
+    });
+  });
+
+  it('should handle return true in expectation functions', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .params(params => params.id === '9999')
+      .once();
+
+    request.post('/foo?id=9999').end(() => {
+      expectation.verify(done);
+    });
+  });
+
+  it('should handle return false in expectation functions', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .params(params => params.id === '1234')
+      .once();
+
+    request.post('/foo?id=9999').end(() => {
+      expectation.verify(err => {
+        if (!err) return done(new Error('expected error'));
+        try {
+          expect(err.message).to.equal(
+            '[post] /foo -- Params did not match expectation callback: function returned false'
+          );
           done();
         } catch (err2) {
           done(err2);

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -488,7 +488,10 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
-        if (!err) return done(new Error('expected error'));
+        if (!err) {
+          done(new Error('expected error'));
+          return;
+        }
         try {
           expect(err.message).to.equal(
             "[post] /foo -- Params did not match expectation callback: expected { id: '9999' } to deeply equal { id: '1234' }"
@@ -512,7 +515,10 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
-        if (!err) return done(new Error('expected error'));
+        if (!err) {
+          done(new Error('expected error'));
+          return;
+        }
         try {
           expect(err.message).to.equal(
             '[post] /foo -- Params did not match expectation callback: my custom assertion error'
@@ -537,7 +543,10 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
-        if (!err) return done(new Error('expected error'));
+        if (!err) {
+          done(new Error('expected error'));
+          return;
+        }
         try {
           expect(err.message).to.equal('[post] /foo -- Params did not match expectation callback');
           done();
@@ -560,7 +569,10 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
-        if (!err) return done(new Error('expected error'));
+        if (!err) {
+          done(new Error('expected error'));
+          return;
+        }
         try {
           expect(err.message).to.equal('[post] /foo -- Params did not match expectation callback');
           done();
@@ -592,7 +604,10 @@ describe('Route expectation', () => {
 
     request.post('/foo?id=9999').end(() => {
       expectation.verify(err => {
-        if (!err) return done(new Error('expected error'));
+        if (!err) {
+          done(new Error('expected error'));
+          return;
+        }
         try {
           expect(err.message).to.equal(
             '[post] /foo -- Params did not match expectation callback: function returned false'


### PR DESCRIPTION
The expect methods with function API may not have been properly handling boolean return values (compounding error messages do to new catch block), and a test for handling errors thrown was incorrect.