### PR TITLE
feat: add fluent way to bind verify to callback

### DIFF
--- a/packages/mockyeah/app/lib/Expectation.js
+++ b/packages/mockyeah/app/lib/Expectation.js
@@ -12,6 +12,7 @@ function Expectation(route) {
   this.called = 0;
   this.assertions = [];
   this.handlers = [];
+  this.callback = undefined;
   return this;
 }
 
@@ -37,6 +38,7 @@ const assertion = function assertion(value, actualValue, message) {
 
 Expectation.prototype.api = function api() {
   const internal = this;
+
   return {
     atLeast: function atLeast(number) {
       internal.assertions.push(() => {
@@ -168,7 +170,21 @@ Expectation.prototype.api = function api() {
       });
       return this;
     },
-    verify: function verify(callback) {
+    done: function done(callback) {
+      internal.callback = callback;
+      return this;
+    },
+    verify: function verify(callbackOrErr) {
+      // Detect if we're using it like `.done(expectation.verify)` (not `expectation.verify(err => {})`),
+      //  where it will be called like a Node callback with optional error argument.
+      if (callbackOrErr && typeof callbackOrErr !== 'function' && internal.callback) {
+        internal.callback(callbackOrErr);
+        return;
+      }
+
+      const argCallback = typeof callbackOrErr === 'function' ? callbackOrErr : undefined;
+      const callback = internal.callback ? internal.callback : argCallback;
+
       try {
         internal.assertions.forEach(_assertion => _assertion());
         if (callback) {

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -452,7 +452,7 @@ describe('Route expectation', () => {
       .end(expectation.verify);
   });
 
-  it.only('should support expectation callback with error', done => {
+  it('should support expectation callback with error', done => {
     const wrappedDone = err => {
       // eslint-disable-next-line no-unused-expressions
       expect(err).to.exist;

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -442,18 +442,23 @@ describe('Route expectation', () => {
       .body({
         foo: 'bar'
       })
-      .once();
+      .once()
+      .done(done);
 
     request
       .post('/foo?id=9999')
       .set('HOST', 'example.com')
       .send({ foo: 'bar' })
-      .end(() => {
-        expectation.verify(done);
-      });
+      .end(expectation.verify);
   });
 
-  it('should support expectation callback with error', done => {
+  it.only('should support expectation callback with error', done => {
+    const wrappedDone = err => {
+      // eslint-disable-next-line no-unused-expressions
+      expect(err).to.exist;
+      done();
+    };
+
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })
       .expect()
@@ -464,15 +469,10 @@ describe('Route expectation', () => {
       .body({
         foo: 'bar'
       })
-      .once();
+      .once()
+      .done(wrappedDone);
 
-    request.post('/foo?id=9999').end(() => {
-      expectation.verify(err => {
-        // eslint-disable-next-line no-unused-expressions
-        expect(err).to.exist;
-        done();
-      });
-    });
+    request.post('/foo?id=9999').end(expectation.verify);
   });
 
   it('should handle custom error in expectation functions', done => {

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -452,10 +452,35 @@ describe('Route expectation', () => {
       .end(expectation.verify);
   });
 
+  it('should support expectation callback with request failure', done => {
+    const wrappedDone = err => {
+      expect(err).to.exist;
+      expect(err.message).to.match(/fake error/);
+      done();
+    };
+
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar', status: 500 })
+      .expect()
+      .header('host', 'example.com')
+      .params({
+        id: '9999'
+      })
+      .body({
+        foo: 'bar'
+      })
+      .once()
+      .done(wrappedDone);
+
+    expectation.verify(new Error('fake error'));
+  });
+
   it('should support expectation callback with error', done => {
     const wrappedDone = err => {
-      // eslint-disable-next-line no-unused-expressions
       expect(err).to.exist;
+      expect(err.message).to.match(
+        /\[post\] \/foo -- Header "host: example.com" expected, but got/
+      );
       done();
     };
 


### PR DESCRIPTION
Add a feature to bind a callback to `.verify` (#216) with the fluent API. First it will check if the callback was past an error (e.g., a failed request), then it will execute the normal `expectation.verify` routine of running the assertions. This makes handlers a bit cleaner. Example:

Instead of:

```js
const expectation = mockyeah
      .post('/foo', { text: 'bar' })
      .once();

    request
      .post('/foo')
      .end(err => {
        if (err) return done(err);
        expectation.verify(done);
      });
```

We can now write:

```js
const expectation = mockyeah
      .post('/foo', { text: 'bar' })
      .once()
      .done(done);

    request
      .post('/foo')
      .end(expectation.verify);
```

Fixes #221
