### PR TITLE
chore: attempt fix coveralls paths

### DIFF
--- a/packages/mockyeah/index.js
+++ b/packages/mockyeah/index.js
@@ -5,5 +5,11 @@
 const Server = require('./server');
 const config = require('./config');
 
+/* eslint-disable */
+if (true === true) {
+  console.log('OK');
+}
+/* eslint-enable */
+
 module.exports = new Server(config);
 module.exports.Server = Server;

--- a/packages/mockyeah/index.js
+++ b/packages/mockyeah/index.js
@@ -5,11 +5,5 @@
 const Server = require('./server');
 const config = require('./config');
 
-/* eslint-disable */
-if (true === true) {
-  console.log('OK');
-}
-/* eslint-enable */
-
 module.exports = new Server(config);
 module.exports.Server = Server;

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -10,7 +10,7 @@
     "test:unit": "mocha test/**/*Test.js test/**/*.test.js",
     "test:coverage": "nyc yarn test:unit",
     "test:coverage:report:html": "nyc yarn test:unit && nyc report --reporter=html",
-    "test:coverage:report": "nyc report --reporter=text-lcov | sed 's/packages\\/mockyeah\\/\\/packages\\/mockyeah\\/packages\\/mockyeah\\//g' | coveralls",
+    "test:coverage:report": "nyc report --reporter=text-lcov | sed 's/packages\\/mockyeah\\//packages\\/mockyeah\\/packages\\/mockyeah\\//g' | coveralls",
     "lint": "eslint -c ./eslint.config.js ./app ./lib ./server ./test"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -10,7 +10,7 @@
     "test:unit": "mocha test/**/*Test.js test/**/*.test.js",
     "test:coverage": "nyc yarn test:unit",
     "test:coverage:report:html": "nyc yarn test:unit && nyc report --reporter=html",
-    "test:coverage:report": "nyc report --reporter=text-lcov | coveralls",
+    "test:coverage:report": "nyc report --reporter=text-lcov | sed 's/packages\\/mockyeah\\/\\/packages\\/mockyeah\\/packages\\/mockyeah\\//g' | coveralls",
     "lint": "eslint -c ./eslint.config.js ./app ./lib ./server ./test"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -10,7 +10,7 @@
     "test:unit": "mocha test/**/*Test.js test/**/*.test.js",
     "test:coverage": "nyc yarn test:unit",
     "test:coverage:report:html": "nyc yarn test:unit && nyc report --reporter=html",
-    "test:coverage:report": "nyc report --reporter=text-lcov | sed 's/packages\\/mockyeah\\//packages\\/mockyeah\\/packages\\/mockyeah\\//g' | coveralls",
+    "test:coverage:report": "nyc report --reporter=text-lcov | coveralls ../..",
     "lint": "eslint -c ./eslint.config.js ./app ./lib ./server ./test"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",


### PR DESCRIPTION
This might fix the coveralls integration which couldn't find our source files ever since we switched to a monorepo with lerna.