### PR TITLE
feat: expect with match object

### DIFF
--- a/docs/book/API/Expectation-API.md
+++ b/docs/book/API/Expectation-API.md
@@ -29,15 +29,58 @@ describe("This test", () => {
 
 <div id="expect"></div>
 
-`.expect(optionalPredicate)` - Returns an expectation object for a given mock service when chained to a [Mock Services API](./Mock-API.md) method call. If provided an optional predicate function, it will call this function on `.verify()`
-where we can throw errors or return true/false to make assertions.
+`.expect(optionalPredicateOrMatchObject)` -
+Returns an expectation object for a given mock service when chained to a [Mock Services API](./Mock-API.md) method call.
+If provided an optional predicate function, it will call this function when `.verify()` is called.
+In this function we can throw errors or return true/false to make assertions.
 It receives one argument - an object with the following fields:
 
+- `method` (String): the request method (lowercase).
 - `path` (String): the request path.
 - `query` (Object): a key/value map of query parameters.
 - `headers` (Object): a key/value map of headers. Header names are all lowercase.
 - `body` (Object|String): the parsed response body. If JSON, then a JS objec, otherwise a string.
 - `req` (Object): the raw Express request object for additional custom assertions.
+
+```js
+const { expect } = reuqire("chai");
+
+const expectation = mockyeah
+  .post("/foo", {
+    text: "bar"
+  })
+  .expect(data => {
+    expect(data.method).to.equal("post");
+    expect(data.path).to.equal("/foo");
+    expect(data.query.id).to.equal("9999");
+    expect(data.headers.host).to.equal("example.com");
+    expect(data.body.foo).to.equal("bar");
+    expect(data.req.originalUrl).to.equal("/foo?id=9999");
+  });
+```
+
+If instead an object is provided, it is a match object with the same power as when mounting mocks.
+It will deep partial match against a view into the request that has the fields above (except `req`),
+and supports matching with string equality, number stringification, regular expressions, functions, etc.
+
+```js
+const expectation = mockyeah
+  .post("/foo", {
+    text: "bar"
+  })
+  .expect({
+    method: "post",
+    path: "/foo",
+    query: {
+      id: /99/,
+      int: 3
+    },
+    headers: value => value.host.includes("example"),
+    body: {
+      foo: "bar"
+    }
+  });
+```
 
 <div id="atLeast">
 

--- a/packages/mockyeah/app/lib/matches.js
+++ b/packages/mockyeah/app/lib/matches.js
@@ -1,0 +1,19 @@
+const { isMatchWith, isRegExp } = require('lodash');
+
+// eslint-disable-next-line consistent-return
+function customizer(object, source) {
+  if (isRegExp(source)) {
+    return source.test(object);
+  } else if (typeof source === 'number') {
+    return source.toString() === object;
+  } else if (typeof source === 'function') {
+    const result = source(object);
+    // if the function returns undefined, we'll skip this to fallback
+    if (result !== undefined) return result;
+  }
+  // else return undefined to fallback to default equality check
+}
+
+const matches = (object, source) => isMatchWith(object, source, customizer);
+
+module.exports = matches;

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -689,7 +689,60 @@ describe('Route expectation', () => {
       });
   });
 
-  it('should support custom generic expect handler', done => {
+  it('should support custom generic expect object', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect({
+        method: 'post',
+        path: '/foo',
+        query: {
+          id: /99/,
+          int: 3
+        },
+        headers: value => value.host.includes('mple'),
+        body: {
+          foo: 'bar'
+        }
+      })
+      .once()
+      .done(done);
+
+    request
+      .post('/foo?id=9999&int=3')
+      .set('HOST', 'example.com')
+      .send({ foo: 'bar' })
+      .end(expectation.verify);
+  });
+
+  it('should support custom generic expect function', done => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect(data => {
+        expect(data).to.exist;
+
+        expect(data.headers).to.be.object;
+        expect(data.query).to.be.object;
+        expect(data.body).to.be.object;
+        expect(data.req).to.be.object;
+
+        expect(data.method).to.equal('post');
+        expect(data.path).to.equal('/foo');
+        expect(data.query.id).to.equal('9999');
+        expect(data.headers.host).to.equal('example.com');
+        expect(data.body.foo).to.equal('bar');
+        expect(data.req.originalUrl).to.equal('/foo?id=9999');
+      })
+      .once()
+      .done(done);
+
+    request
+      .post('/foo?id=9999')
+      .set('HOST', 'example.com')
+      .send({ foo: 'bar' })
+      .end(expectation.verify);
+  });
+
+  it('should support custom generic expect function', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })
       .expect(data => {
@@ -717,35 +770,7 @@ describe('Route expectation', () => {
       });
   });
 
-  it('should support custom generic expect handler', done => {
-    const expectation = mockyeah
-      .post('/foo', { text: 'bar' })
-      .expect(data => {
-        expect(data).to.exist;
-
-        expect(data.headers).to.be.object;
-        expect(data.query).to.be.object;
-        expect(data.body).to.be.object;
-        expect(data.req).to.be.object;
-
-        expect(data.path).to.equal('/foo');
-        expect(data.query.id).to.equal('9999');
-        expect(data.headers.host).to.equal('example.com');
-        expect(data.body.foo).to.equal('bar');
-        expect(data.req.originalUrl).to.equal('/foo?id=9999');
-      })
-      .once();
-
-    request
-      .post('/foo?id=9999')
-      .set('HOST', 'example.com')
-      .send({ foo: 'bar' })
-      .end(() => {
-        expectation.verify(done);
-      });
-  });
-
-  it('should support custom generic expect handler returning true', done => {
+  it('should support custom generic expect function returning true', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })
       .expect(data => data.path === '/foo')
@@ -760,7 +785,7 @@ describe('Route expectation', () => {
       });
   });
 
-  it('should render custom error in expectation functions returning false', done => {
+  it('should render custom error in expect functions returning false', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })
       .expect(data => data.path === '/what')
@@ -780,7 +805,7 @@ describe('Route expectation', () => {
     });
   });
 
-  it('should render custom error in expectation functions with error', done => {
+  it('should render custom error in expect functions with error', done => {
     const expectation = mockyeah
       .post('/foo', { text: 'bar' })
       .expect(() => {


### PR DESCRIPTION
Adds a feature to build expectations with match objects. It will deep partial match against a view into the request, and supports matching with string equality, number stringification, regular expressions, functions, etc.

 ```js
const expectation = mockyeah
  .post("/foo", {
    text: "bar"
  })
  .expect({
    method: "post",
    path: "/foo",
    query: {
      id: /99/,
      int: 3
    },
    headers: value => value.host.includes("example"),
    body: {
      foo: "bar"
    }
  });
```

Fixes #219