### PR TITLE
feat: expect after callback/promise

### DIFF
--- a/docs/book/API/Expectation-API.md
+++ b/docs/book/API/Expectation-API.md
@@ -151,6 +151,21 @@ const expectation = mockyeah
   .header("host", "example.com");
 ```
 
+<div id="after"></div>
+
+`.after(functionOrPromise)` - This will schedule a call to `.verify()`, e.g., after a network call.
+Pass a function which will be called with an argument that is a Node-style callback function reference
+to be executed by you when you're ready for `.verify()` to be called.
+Or pass a promise, which mockyeah will wait for to be settled until calling `.verify()`.
+This is a fluent shorthand so you don't have to assign to an intermediary variable, e.g., `expectation`
+just to be able to call `verify()` later.
+
+<div id="done"></div>
+
+`.done(callback)` - Register a Node-style callback to be called when verification has completed
+after `.verify()` is called, e.g., manually or by having registered with `.after()`.
+Any verification error will be passed to the callback. This is useful for async unit tests.
+
 <div id="verify"></div>
 
 `.verify(callback)` - Asserts expectation to be correct, and if optional callback is provided, using that to pass up assertion errors instead of throwing inline.


### PR DESCRIPTION
Support an "after" syntax that accepts either (A) a promise or (B) a function to be passed a callback, which will wait until (A) is resolved or (B) calls callback, then will internally call `.verify`. This way, there's no need to assign `expectation` to a variable and refer to it later.

```js
mockyeah.get('/foo')
.expect({
  query: { id: 10 }
})
.after(cb => request
  .post('/foo?id=10')
  .set('HOST', 'example.com')
  .send({ foo: 'bar' })
  .end(cb)
);
```

Or with promise:


```js
mockyeah.get('/foo')
.expect({
  query: { id: 10 }
})
.after(fetch('/foo?id=10'));
```

Fixes #229
