### PR TITLE
feat: support dynamic suites by request header

### DIFF
--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -189,5 +189,6 @@ module.exports = {
   normalizePathname,
   replaceFixtureWithRequireInJson,
   handleContentType,
+  handlePathTypes,
   resolveFilePath
 };

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -1,16 +1,47 @@
-const path = require('path');
-
+const _ = require('lodash');
+const nodePath = require('path');
+const { parse } = require('url');
+const isAbsoluteUrl = require('is-absolute-url');
+const pathToRegExp = require('path-to-regexp');
 const {
   decodedPortRegex,
   decodedProtocolRegex,
   encodedPortRegex,
   encodedProtocolRegex
 } = require('./constants');
+const routeHandler = require('./routeHandler');
 
 function resolveFilePath(capturePath, url) {
   const fileName = url.replace(/\//g, '|');
-  return path.resolve(capturePath, fileName);
+  return nodePath.resolve(capturePath, fileName);
 }
+
+const relativizePath = path => (isAbsoluteUrl(path) ? `/${path}` : path);
+
+const justSlashes = /^\/+$/;
+const trailingSlashes = /\/+$/;
+
+const normalizePathname = pathname => {
+  if (!pathname || justSlashes.test(pathname)) return '/';
+  // remove any trailing slashes
+  return pathname.replace(trailingSlashes, '');
+};
+
+// eslint-disable-next-line consistent-return
+const requireSuite = (app, name) => {
+  const { capturesDir } = app.config;
+  const capturePath = nodePath.join(capturesDir, name);
+  const filePath = resolveFilePath(capturePath, 'index.js');
+
+  try {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    const captures = require(filePath);
+
+    return captures;
+  } catch (err) {
+    app.log(['capture', 'error'], `No such capture ${name} found.`);
+  }
+};
 
 const handleContentType = (body, headers) => {
   const contentType = headers['content-type'];
@@ -72,9 +103,91 @@ const decodeProtocolAndPort = str =>
 const encodeProtocolAndPort = str =>
   str.replace(decodedPortRegex, '$1~').replace(decodedProtocolRegex, '$1~~~');
 
-exports.decodeProtocolAndPort = decodeProtocolAndPort;
-exports.encodeProtocolAndPort = encodeProtocolAndPort;
-exports.getDataForRecordToFixtures = getDataForRecordToFixtures;
-exports.replaceFixtureWithRequireInJson = replaceFixtureWithRequireInJson;
-exports.handleContentType = handleContentType;
-exports.resolveFilePath = resolveFilePath;
+const handlePathTypes = (_path, _query) => {
+  if (typeof _path === 'string') {
+    const path = relativizePath(_path);
+    const url = parse(path, true);
+    const pathname = normalizePathname(url.pathname);
+
+    // Encode absolute URL protocol and port characters to tildes to prevent colons from being interpreted as Express parameters.
+    const paramEncodedPathname = encodeProtocolAndPort(pathname);
+
+    const matchKeys = [];
+    // `pathToRegExp` mutates `matchKeys` to contain a list of named parameters
+    const pathRegExp = pathToRegExp(paramEncodedPathname, matchKeys);
+
+    const query = Object.assign({}, url.query, _query);
+
+    return {
+      matchKeys,
+      path,
+      pathFn: p => pathRegExp.test(encodeProtocolAndPort(p)),
+      pathname,
+      pathRegExp,
+      query
+    };
+  }
+
+  if (_path instanceof RegExp) {
+    // TODO: Maybe support `matchKeys` with index of match or maybe even named capture groups?
+
+    return {
+      path: _path,
+      pathFn: p => _path.test(decodeProtocolAndPort(p)),
+      pathname: _path
+    };
+  }
+
+  if (typeof _path === 'function') {
+    return {
+      path: _path,
+      pathFn: p => _path(decodeProtocolAndPort(p)),
+      pathname: _path
+    };
+  }
+
+  throw new Error(`Unsupported path type ${typeof _path}: ${_path}`);
+};
+
+const compileRoute = (app, match, response) => {
+  const { method } = match;
+
+  const route = {
+    method,
+    response
+  };
+
+  if (!_.isFunction(route.response)) {
+    route.response = routeHandler(app, route);
+  }
+
+  if (!_.isPlainObject(match)) {
+    Object.assign(route, handlePathTypes(match));
+  } else {
+    const object = match;
+    const headers = _.mapKeys(object.headers, (value, key) => key.toLowerCase());
+
+    Object.assign(
+      route,
+      handlePathTypes(typeof object.path !== 'undefined' ? object.path : object.url, object.query),
+      {
+        body: object.body,
+        headers
+      }
+    );
+  }
+
+  return route;
+};
+
+module.exports = {
+  compileRoute,
+  requireSuite,
+  decodeProtocolAndPort,
+  encodeProtocolAndPort,
+  getDataForRecordToFixtures,
+  normalizePathname,
+  replaceFixtureWithRequireInJson,
+  handleContentType,
+  resolveFilePath
+};

--- a/packages/mockyeah/app/player.js
+++ b/packages/mockyeah/app/player.js
@@ -1,14 +1,11 @@
-const path = require('path');
-const { resolveFilePath } = require('./lib/helpers');
+const { requireSuite } = require('./lib/helpers');
 
 module.exports = app => name => {
-  const { capturesDir } = app.config;
-  const capturePath = path.join(capturesDir, name);
-  const filePath = resolveFilePath(capturePath, 'index.js');
-  // eslint-disable-next-line import/no-dynamic-require, global-require
-  const captures = require(filePath);
+  const capture = requireSuite(app, name);
+
+  if (!capture) return;
 
   app.log(['serve', 'play'], name);
 
-  captures.map(capture => app.routeManager.all(...capture));
+  capture.map(c => app.routeManager.all(...c));
 };

--- a/packages/mockyeah/test/integration/DynamicSuiteTest.js
+++ b/packages/mockyeah/test/integration/DynamicSuiteTest.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const TestHelper = require('../TestHelper');
+
+const { request } = TestHelper;
+
+describe('Dynamic Suites', function() {
+  it('should dynamically enable a suite per-request', function(done) {
+    request
+      .get('/say-hello')
+      .set('x-mockyeah-suite', 'some-custom-capture')
+      .expect(200, /hello there/, done);
+  });
+
+  it('should ignore non-existent dynamic suite', function(done) {
+    request
+      .get('/say-hello')
+      .set('x-mockyeah-suite', 'some-nonexistent-capture')
+      .expect(404, done);
+  });
+});

--- a/packages/mockyeah/test/unit/helpers.test.js
+++ b/packages/mockyeah/test/unit/helpers.test.js
@@ -3,7 +3,9 @@
 const { expect } = require('chai');
 
 const {
+  compileRoute,
   handleContentType,
+  handlePathTypes,
   replaceFixtureWithRequireInJson,
   getDataForRecordToFixtures
 } = require('../../app/lib/helpers');
@@ -38,6 +40,22 @@ describe('app helpers', () => {
           foo: 'bar'
         }
       });
+    });
+  });
+
+  describe('compileRoute', () => {
+    it('works for strings', () => {
+      const app = {};
+      const match = {
+        path: '/'
+      };
+      expect(compileRoute(app, match).path).to.equal('/');
+    });
+  });
+
+  describe('handlePathTypes', () => {
+    it('throws for unknown type', () => {
+      expect(handlePathTypes.bind(1)).to.throw();
     });
   });
 


### PR DESCRIPTION
Adds a feature to support dynamically opting into suites that are not mounted with `play` on a per-request basis using a request header `x-mockyeah-suite` matching the capture name. Unfortunately, suites will still stay in Node's `require` cache, so we can't ingest any changes to files between requests, unless we add additional features to clear the require cache on-demand, or even support a watch mode (#238).

There was some somewhat aggressive internal refactoring to support this. We'll be cleaning this up in future PRs, including possibly renaming "captures" to "suites" (#239).

This does not document yet, as we'll test it in some more real uses case before possibly tweaking then advertising.
