### PR TITLE
feat: add a watch mode

### DIFF
--- a/packages/mockyeah/app/index.js
+++ b/packages/mockyeah/app/index.js
@@ -10,6 +10,7 @@ const recorder = require('./recorder');
 const recordStopper = require('./recordStopper');
 const player = require('./player');
 const playAller = require('./playAller');
+const watcher = require('./watcher');
 
 /**
  * App module
@@ -62,6 +63,9 @@ module.exports = function App(config) {
 
   app.locals.proxying = app.config.proxy;
 
+  app.locals.playingSuites = [];
+  app.locals.playingAll = false;
+
   app.locals.recording = app.config.record;
   app.locals.recordMeta = {};
 
@@ -78,6 +82,8 @@ module.exports = function App(config) {
 
   app.reset = () => {
     app.routeManager.reset();
+    app.locals.playingSuites = [];
+    app.locals.playingAll = false;
     app.locals.proxying = app.config.proxy;
     app.middlewares = [];
   };
@@ -85,6 +91,8 @@ module.exports = function App(config) {
   app.use = middleware => {
     app.middlewares.push(middleware);
   };
+
+  app.watch = watcher(app);
 
   return app;
 };

--- a/packages/mockyeah/app/playAller.js
+++ b/packages/mockyeah/app/playAller.js
@@ -17,5 +17,7 @@ module.exports = app => () => {
     dirs.forEach(file => {
       app.play(file);
     });
+
+    app.locals.playingAll = true;
   });
 };

--- a/packages/mockyeah/app/player.js
+++ b/packages/mockyeah/app/player.js
@@ -5,6 +5,8 @@ module.exports = app => name => {
 
   if (!capture) return;
 
+  app.locals.playingSuites.push(name);
+
   app.log(['serve', 'play'], name);
 
   capture.map(c => app.routeManager.all(...c));

--- a/packages/mockyeah/app/watcher.js
+++ b/packages/mockyeah/app/watcher.js
@@ -1,0 +1,43 @@
+const _ = require('lodash');
+const chokidar = require('chokidar');
+const clearModule = require('clear-module');
+
+const watcher = app => {
+  const { capturesDir, fixturesDir } = app.config;
+
+  let first = true;
+  const debounced = _.debounce(() => {
+    if (first) {
+      first = false;
+      return;
+    }
+
+    clearModule.match(new RegExp(capturesDir));
+    clearModule.match(new RegExp(fixturesDir));
+
+    const wasPlayingSuites = app.locals.playingSuites;
+    const wasPlayingAll = app.locals.playingAll;
+
+    app.reset();
+
+    if (wasPlayingAll) {
+      app.playAll();
+    } else {
+      wasPlayingSuites.forEach(name => {
+        app.play(name);
+      });
+    }
+  }, 500);
+
+  const watch = () => {
+    chokidar.watch([capturesDir, fixturesDir]).on('all', debounced);
+  };
+
+  if (app.config.watch) {
+    watch();
+  }
+
+  return watch;
+};
+
+module.exports = watcher;

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -20,7 +20,8 @@ const configDefaults = {
   adminPort: 4777,
   recordToFixtures: true,
   recordToFixturesMode: 'path',
-  formatScript: undefined
+  formatScript: undefined,
+  watch: false
 };
 
 module.exports = (config = {}) => {

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -72,6 +72,8 @@
   "dependencies": {
     "async": "^1.5.2",
     "body-parser": "^1.15.2",
+    "chokidar": "^2.0.4",
+    "clear-module": "^3.1.0",
     "cors": "^2.7.1",
     "create-cert-files": "^1.0.2",
     "express": "^4.13.3",

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -41,7 +41,8 @@ describe('prepareConfig', () => {
       verbose: false,
       recordToFixtures: true,
       recordToFixturesMode: 'path',
-      formatScript: undefined
+      formatScript: undefined,
+      watch: false
     });
   });
 
@@ -66,7 +67,8 @@ describe('prepareConfig', () => {
       verbose: false,
       recordToFixtures: true,
       recordToFixturesMode: 'path',
-      formatScript: undefined
+      formatScript: undefined,
+      watch: false
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,6 +1034,10 @@ callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
+callsites@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -1110,7 +1114,7 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
-chokidar@^2.0.2:
+chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
@@ -1149,6 +1153,13 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clear-module@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/clear-module/-/clear-module-3.1.0.tgz#611c88aa8176b35678687f2085187a45095792e5"
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 clear-require@^2.0.0:
   version "2.0.0"
@@ -4272,6 +4283,12 @@ parallel-transform@^1.1.0:
     cyclist "~0.2.2"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
+
+parent-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
+  dependencies:
+    callsites "^3.0.0"
 
 parse-filepath@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This adds a watch mode for the captures and fixtures using `chokidar`. It will remember which captures were playing (either all from a `playAll` call, or specific captures by name via `play`), then call `reset` and clear the Node require cache for the captures and fixtures directories, then re-play the captures it remember were playing.

Fixes #238.

This does not document yet, as we'll test it in some more real uses case before possibly tweaking then advertising.
