### PR TITLE
fix: undefined log for play all

### DIFF
--- a/packages/mockyeah/app/playAller.js
+++ b/packages/mockyeah/app/playAller.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = app => () => {
   const { capturesDir } = app.config;
 
-  app.log(['serve', 'play all']);
+  app.log(['serve'], 'play all');
 
   fs.readdir(capturesDir, (err, files) => {
     if (err) throw err;


### PR DESCRIPTION
There was a bug with logging in `.playAll()` which had `undefined` as a message.