### PR TITLE
fix: compile route default method get

### DIFF
--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -152,10 +152,8 @@ const handlePathTypes = (_path, _query) => {
 };
 
 const compileRoute = (app, match, response) => {
-  const { method } = match;
-
   const route = {
-    method,
+    method: match.method || 'get',
     response
   };
 

--- a/packages/mockyeah/test/unit/helpers.test.js
+++ b/packages/mockyeah/test/unit/helpers.test.js
@@ -46,9 +46,25 @@ describe('app helpers', () => {
   describe('compileRoute', () => {
     it('works for strings', () => {
       const app = {};
+      const match = '/';
+      expect(compileRoute(app, match).path).to.equal('/');
+    });
+
+    it('works for objects without method', () => {
+      const app = {};
       const match = {
         path: '/'
       };
+      expect(compileRoute(app, match).path).to.equal('/');
+    });
+
+    it('works for objects with method', () => {
+      const app = {};
+      const match = {
+        method: 'post',
+        path: '/'
+      };
+      expect(compileRoute(app, match).method).to.equal('post');
       expect(compileRoute(app, match).path).to.equal('/');
     });
   });


### PR DESCRIPTION
Fixing a bug where we weren't defaulting to `get` as a method when compiling routes - especially needed for dynamic suites (#240).