### PR TITLE
fix: stringify number for expectation match

### DIFF
--- a/packages/mockyeah/app/lib/matches.js
+++ b/packages/mockyeah/app/lib/matches.js
@@ -5,7 +5,7 @@ function customizer(object, source) {
   if (isRegExp(source)) {
     return source.test(object);
   } else if (typeof source === 'number') {
-    return source.toString() === object;
+    return (source && source.toString()) === (object && object.toString());
   } else if (typeof source === 'function') {
     const result = source(object);
     // if the function returns undefined, we'll skip this to fallback

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -270,6 +270,31 @@ describe('Route expectation', () => {
     );
   });
 
+  it('should implement params() expectation with number', done => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .params({
+        id: 9999
+      });
+
+    async.series(
+      [
+        cb => request.get('/foo?id=9999').end(cb),
+        cb => {
+          expectation.verify();
+          cb();
+        },
+        cb => request.get('/foo').end(cb),
+        cb => {
+          expect(expectation.verify).to.throw('Params did not match expected');
+          cb();
+        }
+      ],
+      done
+    );
+  });
+
   it('should implement params() expectation with nested regex', done => {
     const expectation = mockyeah
       .get('/foo', { text: 'bar' })


### PR DESCRIPTION
Currently, expectations weren't working with numbers against strings, since we added support for match objects in #234.