### PR TITLE
feat: only record status if not 200

### DIFF
--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -107,12 +107,13 @@ const proxyRoute = (req, res, next) => {
     // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
     delete headers['transfer-encoding'];
 
-    const responseOptions = Object.assign(
-      {
-        status
-      },
-      handleContentType(_body, headers)
-    );
+    let responseOptions = {};
+
+    if (status !== 200) {
+      responseOptions.status = status;
+    }
+
+    responseOptions = Object.assign(responseOptions, handleContentType(_body, headers));
 
     if (useHeaders) {
       responseOptions.headers = headers;

--- a/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordAndPlayTest.js
@@ -654,7 +654,7 @@ describe('Capture Record and Playback', function() {
     remote.get('/some/service/two', { json: { second: true } });
     remote.get('/some/service/three', { text: 'third' });
     remote.get('/some/service/four', { text: 'fourth' });
-    remote.get('/some/service/five', { text: 'fifth' });
+    remote.get('/some/service/five', { text: 'fifth', status: 206 });
 
     // Initiate recording and playback series
     async.series(
@@ -671,7 +671,7 @@ describe('Capture Record and Playback', function() {
         cb => proxyReq.get(path2).expect(200, '{"second":true}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, 'fourth', cb),
-        cb => proxyReq.get(path5).expect(200, 'fifth', cb),
+        cb => proxyReq.get(path5).expect(206, 'fifth', cb),
 
         // Stop recording but pretend there's a file write error.
         cb => {
@@ -716,7 +716,7 @@ describe('Capture Record and Playback', function() {
         cb => remoteReq.get(path2).expect(200, '{"second":true}', cb),
         cb => remoteReq.get(path3).expect(200, 'third', cb),
         cb => remoteReq.get(path4).expect(200, 'fourth', cb),
-        cb => remoteReq.get(path5).expect(200, 'fifth', cb),
+        cb => remoteReq.get(path5).expect(206, 'fifth', cb),
 
         // Assert paths are routed the correct responses
         // e.g. http://localhost:4041/some/service
@@ -724,7 +724,7 @@ describe('Capture Record and Playback', function() {
         cb => proxyReq.get(path2).expect(200, '{\n  "second": true\n}', cb),
         cb => proxyReq.get(path3).expect(200, 'third', cb),
         cb => proxyReq.get(path4).expect(200, 'fourth', cb),
-        cb => proxyReq.get(path5).expect(200, 'fifth', cb)
+        cb => proxyReq.get(path5).expect(206, 'fifth', cb)
       ],
       done
     );

--- a/packages/mockyeah/test/integration/CaptureRecordFormatScriptFileTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordFormatScriptFileTest.js
@@ -104,7 +104,7 @@ describe('Capture Record Format Script File Test', function() {
           const contents = fs.readFileSync(getCaptureFilePath(captureName), 'utf8');
           expect(contents).to.match(
             // eslint-disable-next-line no-regex-spaces
-            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "status": 200,       "raw": ""     }   \] ];/
+            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "raw": ""     }   \] ];/
           );
           cb();
         },

--- a/packages/mockyeah/test/integration/CaptureRecordFormatScriptFunctionTest.js
+++ b/packages/mockyeah/test/integration/CaptureRecordFormatScriptFunctionTest.js
@@ -105,7 +105,7 @@ describe('Capture Record Format Script Function Test', function() {
           const contents = fs.readFileSync(getCaptureFilePath(captureName), 'utf8');
           expect(contents).to.match(
             // eslint-disable-next-line no-regex-spaces
-            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "status": 200,       "raw": ""     }   \] ];/
+            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "raw": ""     }   \] ];/
           );
           cb();
         },


### PR DESCRIPTION
No need to record the `status` field to captures when it's `200` since we default to that anyway.