### PR TITLE
feat: mockyeah response headers for mocked/proxied

### DIFF
--- a/packages/mockyeah/app/lib/routeHandler.js
+++ b/packages/mockyeah/app/lib/routeHandler.js
@@ -146,6 +146,10 @@ module.exports = function handler(app, route) {
     // set response headers, if received
     if (response.headers) res.set(response.headers);
 
+    if (app.config.responseHeaders) {
+      res.set('x-mockyeah-mocked', 'true');
+    }
+
     const handleDataBound = handleData.bind(null, req, res, next);
 
     if (response.filePath) {

--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -123,7 +123,13 @@ const proxyRoute = (req, res, next) => {
     }
 
     recordMeta.set.push([match, responseOptions]);
-  }).pipe(res);
+  })
+    .on('response', _res => {
+      if (app.config.responseHeaders) {
+        _res.headers['x-mockyeah-proxied'] = 'true';
+      }
+    })
+    .pipe(res);
 };
 
 // Export for testing purposes.

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -21,7 +21,8 @@ const configDefaults = {
   recordToFixtures: true,
   recordToFixturesMode: 'path',
   formatScript: undefined,
-  watch: false
+  watch: false,
+  responseHeaders: true
 };
 
 module.exports = (config = {}) => {

--- a/packages/mockyeah/test/integration/RouteProxyNoHeadersTest.js
+++ b/packages/mockyeah/test/integration/RouteProxyNoHeadersTest.js
@@ -25,7 +25,8 @@ describe('Route proxy', () => {
             {
               port: 0,
               adminPort: 0,
-              proxy: true
+              proxy: true,
+              responseHeaders: false
             },
             cb
           );
@@ -88,8 +89,17 @@ describe('Route proxy', () => {
         cb =>
           request
             .get(`/http://localhost:${proxiedPort}/foo?ok=yes`)
-            .expect('x-mockyeah-mocked', 'true')
-            .expect(500, 'bar', cb)
+            .expect(500, 'bar')
+            .end((err, res) => {
+              if (err) {
+                cb(err);
+                return;
+              }
+
+              expect(res.headers).to.not.have.key('x-mockyeah-mocked');
+
+              cb();
+            })
       ],
       done
     );
@@ -139,8 +149,17 @@ describe('Route proxy', () => {
 
     request
       .get(`/http://localhost:${proxiedPort}/foo?ok=yes`)
-      .expect('x-mockyeah-proxied', 'true')
-      .expect(200, done);
+      .expect(200)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        expect(res.headers).to.not.have.key('x-mockyeah-proxied');
+
+        done();
+      });
   });
 
   it('should bypass non-mounted, non-absolute URLs', done => {

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -42,7 +42,8 @@ describe('prepareConfig', () => {
       recordToFixtures: true,
       recordToFixturesMode: 'path',
       formatScript: undefined,
-      watch: false
+      watch: false,
+      responseHeaders: true
     });
   });
 
@@ -68,7 +69,8 @@ describe('prepareConfig', () => {
       recordToFixtures: true,
       recordToFixturesMode: 'path',
       formatScript: undefined,
-      watch: false
+      watch: false,
+      responseHeaders: true
     });
   });
 });


### PR DESCRIPTION
Adds headers `x-mockyeah-mocked: true` and `x-mockyeah-proxied: true` on responses so it's easier to tell what's happening, whether your mocks are matching, etc. This is on by default but can be turned off in configuration as `responseHeaders: false`.

May add documentation in a follow-up PR.
