### PR TITLE
fix: don't forward x-mockyeah-suite onto proxied service

### DIFF
--- a/packages/mockyeah/app/proxyRoute.js
+++ b/packages/mockyeah/app/proxyRoute.js
@@ -104,6 +104,9 @@ const proxyRoute = (req, res, next) => {
 
     const headers = Object.assign({}, __headers);
 
+    // Don't forward the suite header onto the proxied service.
+    delete headers['x-mockyeah-suite'];
+
     // Don't record the `transfer-encoding` header since `chunked` value can cause `ParseError`s with `request`.
     delete headers['transfer-encoding'];
 


### PR DESCRIPTION
When we added the dynamic suite header functionality in #240, we didn't delete it from being forwarded onto the proxied service.