### PR TITLE
fix: decode urls for alias check

### DIFF
--- a/packages/mockyeah/app/lib/RouteResolver.js
+++ b/packages/mockyeah/app/lib/RouteResolver.js
@@ -55,7 +55,7 @@ function isRouteForRequest(app, route, req) {
       const matchesAnyAliases = Object.keys(aliasReplacements).some(toReplace => {
         const aliases = aliasReplacements[toReplace];
         return aliases.some(alias => {
-          const aliasedPathname = pathname.replace(toReplace, alias);
+          const aliasedPathname = decodedPathname.replace(toReplace, alias);
           const matchesAlias = route.pathFn(aliasedPathname);
           return matchesAlias;
         });

--- a/packages/mockyeah/test/integration/DynamicSuiteTest.js
+++ b/packages/mockyeah/test/integration/DynamicSuiteTest.js
@@ -41,6 +41,13 @@ describe('Dynamic Suites', function() {
       .expect(200, /hello absolute/, done);
   });
 
+  it('should support aliases with encoding', function(done) {
+    request
+      .get('/http~~~localhost.alias.com/say-hello')
+      .set('x-mockyeah-suite', 'some-custom-capture')
+      .expect(200, /hello absolute/, done);
+  });
+
   it('should ignore non-existent dynamic suite', function(done) {
     request
       .get('/say-hello')

--- a/packages/mockyeah/test/integration/RouteProxyMethodTest.js
+++ b/packages/mockyeah/test/integration/RouteProxyMethodTest.js
@@ -119,6 +119,24 @@ describe('Route proxy method', () => {
     );
   });
 
+  it('should support registering full URLs manually with environment aliases with encoding', done => {
+    mockyeah.get(`http://localhost.alias.com:${proxiedPort}/foo?ok=yes`, {
+      text: 'bar',
+      status: 500
+    });
+
+    async.series(
+      [
+        cb =>
+          supertest(proxiedApp)
+            .get('/foo')
+            .expect(200, cb),
+        cb => request.get(`/http~~~localhost~${proxiedPort}/foo?ok=yes`).expect(500, 'bar', cb)
+      ],
+      done
+    );
+  });
+
   describe('custom-encoded URLs', () => {
     it('should support registering full URLs and matching request with custom-encoded URLs', done => {
       mockyeah.get(`/http://localhost:${proxiedPort}/foo?ok=yes`, { text: 'bar', status: 500 });


### PR DESCRIPTION
With the aliases feature, we forgot to decode pathnames (which can be optionally encoded) before checking. This fixes that.