### PR TITLE
chore: add prettier and format markdown

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,4 +21,3 @@ To publish an archive version to a subfolder of `gh-pages` branch, use:
 yarn build
 yarn docs:publish:archive archive/0.16
 ```
-

--- a/docs/book/API/Mock-API.md
+++ b/docs/book/API/Mock-API.md
@@ -17,14 +17,14 @@ This fully supports all Express path matching options.
 Examples:
 
 ```js
-mockyeah.get('/say-hello', { text: 'hello' });
+mockyeah.get("/say-hello", { text: "hello" });
 
-mockyeah.get('/say-hello/:person', { text: 'hello, person' });
+mockyeah.get("/say-hello/:person", { text: "hello, person" });
 
-mockyeah.get('/say-hello?to=someone', { text: 'hello, someone' });
+mockyeah.get("/say-hello?to=someone", { text: "hello, someone" });
 
 // or regex path match:
-mockyeah.get(/say-[a-z]+/, { text: 'something, someone' });
+mockyeah.get(/say-[a-z]+/, { text: "something, someone" });
 ```
 
 If you want the mock to match only for specific headers, query parameters, or request body,
@@ -76,25 +76,25 @@ Examples:
 ```js
 mockyeah.post(
   {
-    path: '/say-hello',
+    path: "/say-hello",
     headers: {
-      'X-API-Key': /[0-9A-F]{32}/i
+      "X-API-Key": /[0-9A-F]{32}/i
     },
     body: {
-      to: 'friend'
+      to: "friend"
     }
   },
-  { text: 'hello, friend' }
+  { text: "hello, friend" }
 );
 ```
 
 ```js
 mockyeah.all(
   {
-    path: '/say-hello',
-    method: 'get'
+    path: "/say-hello",
+    method: "get"
   },
-  { text: 'hello, friend' }
+  { text: "hello, friend" }
 );
 ```
 
@@ -105,13 +105,13 @@ Response options informing mockyeah how to respond to matching requests. Support
 
 **One of the following options may be used per service:**
 
-* `filePath` (`String`; optional) - File with contents to include in response body. Assumes response Content-Type of file type.
-* `fixture` (`String`; optional) - Fixture file with contents to include in response body. Assumes response Content-Type of file type. Default fixture file location is `./fixtures` in your project.
+- `filePath` (`String`; optional) - File with contents to include in response body. Assumes response Content-Type of file type.
+- `fixture` (`String`; optional) - Fixture file with contents to include in response body. Assumes response Content-Type of file type. Default fixture file location is `./fixtures` in your project.
 
-* `html` (`String|Function|Promise`; optional) - HTML to include in response body. Assumes response Content-Type of `text/html`.
-* `json` (`Object|Function|Promise`; optional) - JSON to include in response body. Assumes response Content-Type of `application/json`.
-* `raw` (`String|Function|Promise`; optional) - Text to include in response body. Content-Type is the default Express type if not specified in header.
-* `text` (`String|Function|Promise`; optional) - Text to include in response body. Assumes response Content-Type of `text/plain`.
+- `html` (`String|Function|Promise`; optional) - HTML to include in response body. Assumes response Content-Type of `text/html`.
+- `json` (`Object|Function|Promise`; optional) - JSON to include in response body. Assumes response Content-Type of `application/json`.
+- `raw` (`String|Function|Promise`; optional) - Text to include in response body. Content-Type is the default Express type if not specified in header.
+- `text` (`String|Function|Promise`; optional) - Text to include in response body. Assumes response Content-Type of `text/plain`.
 
 For dynamic behavior, the noted methods above can also be defined as functions that return response body values.
 For asynchronous behavior, they can be defined as promises that resolve with such values, or a functions that return such promises.
@@ -120,20 +120,22 @@ The functions will receive the Express request object as a first and only argume
 Examples:
 
 ```js
-mockyeah.get('/service/exists', { json: req => ({ hello: req.query.name }) });
+mockyeah.get("/service/exists", { json: req => ({ hello: req.query.name }) });
 ```
 
 ```js
-mockyeah.get('/service/exists', { json: req => Promise.resolve({ hello: req.query.name }) });
+mockyeah.get("/service/exists", {
+  json: req => Promise.resolve({ hello: req.query.name })
+});
 ```
 
 ```js
-mockyeah.get('/service/exists', { json: Promise.resolve({ hello: 'there' }) });
+mockyeah.get("/service/exists", { json: Promise.resolve({ hello: "there" }) });
 ```
 
 **Additional options:**
 
-* `headers` (`Object`; optional) - Header key value pairs to include in response.
-* `latency` (`Number` in Milliseconds; optional) - Used to control the response timing of a response.
-* `type` (`String`; optional) - Content-Type HTTP header to return with response. Proxies option to Express response method `res.type(type)`; more info here: http://expressjs.com/en/4x/api.html#res.type
-* `status` (`String`; optional; default: `200`) - HTTP response status code.
+- `headers` (`Object`; optional) - Header key value pairs to include in response.
+- `latency` (`Number` in Milliseconds; optional) - Used to control the response timing of a response.
+- `type` (`String`; optional) - Content-Type HTTP header to return with response. Proxies option to Express response method `res.type(type)`; more info here: http://expressjs.com/en/4x/api.html#res.type
+- `status` (`String`; optional; default: `200`) - HTTP response status code.

--- a/docs/book/API/Server.md
+++ b/docs/book/API/Server.md
@@ -10,19 +10,19 @@ Use it to programmatically construct your own instance of mockyeah, perhaps with
 First import it:
 
 ```js
-import { Server } from 'mockyeah';
+import { Server } from "mockyeah";
 ```
 
 or:
 
 ```js
-const { Server } = require('mockyeah');
+const { Server } = require("mockyeah");
 ```
 
 or:
 
 ```js
-const Server = require('mockyeah').Server;
+const Server = require("mockyeah").Server;
 ```
 
 Then use it:

--- a/docs/book/API/reset.md
+++ b/docs/book/API/reset.md
@@ -10,10 +10,10 @@ afterEach(() => mockyeah.reset());
 You may remove specific services by passing paths matching services to unmount. Example:
 
 ```js
-mockyeah.get('/foo-1', { text: 'bar' });
-mockyeah.get('/foo-2', { text: 'bar' });
-mockyeah.get('/foo-3', { text: 'bar' });
+mockyeah.get("/foo-1", { text: "bar" });
+mockyeah.get("/foo-2", { text: "bar" });
+mockyeah.get("/foo-3", { text: "bar" });
 
 // unmounts only /foo-1 and /foo-2
-mockyeah.reset('/foo-1', '/bar-2');
+mockyeah.reset("/foo-1", "/bar-2");
 ```

--- a/docs/book/Getting-Started.md
+++ b/docs/book/Getting-Started.md
@@ -40,9 +40,9 @@ yarn add -D mockyeah
     ```
 
     ```js
-    const mockyeah = require('mockyeah');
+    const mockyeah = require("mockyeah");
 
-    mockyeah.get('/hello-world', { text: 'Hello World' });
+    mockyeah.get("/hello-world", { text: "Hello World" });
     ```
 
 1.  Run the script file with Node
@@ -58,46 +58,46 @@ yarn add -D mockyeah
 ## Testing with mockyeah
 
 ```js
-const request = require('supertest')('http://localhost:4001');
-const mockyeah = require('mockyeah');
+const request = require("supertest")("http://localhost:4001");
+const mockyeah = require("mockyeah");
 
-describe('Wondrous service', () => {
+describe("Wondrous service", () => {
   // remove service mocks after each test
   afterEach(() => mockyeah.reset());
 
   // stop mockyeah server
   after(() => mockyeah.close());
 
-  it('should create a mock service that returns an internal error', done => {
+  it("should create a mock service that returns an internal error", done => {
     // create failing service mock
-    mockyeah.get('/wondrous', { status: 500 });
+    mockyeah.get("/wondrous", { status: 500 });
 
     // assert service mock is working
-    request.get('/wondrous').expect(500, done);
+    request.get("/wondrous").expect(500, done);
   });
 
-  it('should create a mock service that returns JSON', done => {
+  it("should create a mock service that returns JSON", done => {
     // create service mock that returns json data
-    mockyeah.get('/wondrous', { json: { foo: 'bar' } });
+    mockyeah.get("/wondrous", { json: { foo: "bar" } });
 
     // assert service mock is working
-    request.get('/wondrous').expect(200, { foo: 'bar' }, done);
+    request.get("/wondrous").expect(200, { foo: "bar" }, done);
   });
 
-  it('should verify a mock service expectation', done => {
+  it("should verify a mock service expectation", done => {
     // create service mock with expectation
     const expectation = mockyeah
-      .get('/wondrous', { text: 'it worked' })
+      .get("/wondrous", { text: "it worked" })
       .expect()
       .params({
-        foo: 'bar'
+        foo: "bar"
       })
       .once();
 
     // invoke request and verify expectation
     request
-      .get('/wondrous?foo=bar')
-      .expect(200, 'it worked')
+      .get("/wondrous?foo=bar")
+      .expect(200, "it worked")
       .then(() => {
         expectation.verify(done);
       });

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -9,6 +9,7 @@
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.9.0",
-    "eslint-plugin-node": "^6.0.1"
+    "eslint-plugin-node": "^6.0.1",
+    "prettier": "^1.16.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4459,6 +4459,10 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
+prettier@^1.16.3:
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.3.tgz#8c62168453badef702f34b45b6ee899574a6a65d"
+
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"


### PR DESCRIPTION
Adds `prettier` CLI to `tools` package, and formats Markdown files in `docs` and all `README.md`s.