### PR TITLE
fix: restore no config behavior

### DIFF
--- a/packages/mockyeah/config.js
+++ b/packages/mockyeah/config.js
@@ -21,19 +21,18 @@ try {
   throw new Error(`Error searching for configuration file: ${error.message}`);
 }
 
-const { filepath } = searchedFor;
+const { filepath } = searchedFor || {};
 
-if (!filepath) {
-  throw new Error(`No configuration file found.`);
+let config;
+
+if (filepath) {
+  try {
+    const loaded = explorer.loadSync(filepath);
+    // eslint-disable-next-line prefer-destructuring
+    config = loaded.config;
+  } catch (error) {
+    throw new Error(`Error loading configuration file "${filepath}": ${error.message}`);
+  }
 }
-
-let loaded;
-try {
-  loaded = explorer.loadSync(filepath);
-} catch (error) {
-  throw new Error(`Error loading configuration file "${filepath}": ${error.message}`);
-}
-
-const { config } = loaded;
 
 module.exports = prepareConfig(config);

--- a/packages/mockyeah/test/integration/ConfigTest.js
+++ b/packages/mockyeah/test/integration/ConfigTest.js
@@ -6,6 +6,21 @@ const { exec } = require('child_process');
 const { expect } = require('chai');
 
 describe('Config', () => {
+  it('should work without config', function(done) {
+    exec(
+      `echo "
+      const mockyeah = require('./index');
+      setTimeout(() => {
+        process.exit();
+      }, 1000)
+      " | node`,
+      function(err, stdout) {
+        expect(stdout).to.include('mockyeah');
+        done();
+      }
+    );
+  });
+
   it('should write output to stdout by default', function(done) {
     exec(
       `echo "


### PR DESCRIPTION
With #261, we may have broken ability to run without a config. This fixes it, and adds a test so this doesn't happen again.