### PR TITLE
test: correct mockyeah root

### DIFF
--- a/packages/mockyeah/app/lib/routeHandler.js
+++ b/packages/mockyeah/app/lib/routeHandler.js
@@ -154,7 +154,7 @@ module.exports = function handler(app, route) {
 
     if (response.filePath) {
       // if filePath, send file
-      const filePath = expandPath(response.filePath);
+      const filePath = expandPath(response.filePath, app.config.root);
       if (response.type) res.type(response.type);
       verifyFile(app, filePath, '`filePath` option invalid, file not found at ' + filePath);
       send = res.sendFile.bind(res, filePath);

--- a/packages/mockyeah/lib/expandPath.js
+++ b/packages/mockyeah/lib/expandPath.js
@@ -3,6 +3,6 @@
 const path = require('path');
 const relativeRoot = require('./relativeRoot');
 
-module.exports = function expandPath(_path) {
-  return path.isAbsolute(_path) ? _path : path.resolve(relativeRoot, _path);
+module.exports = function expandPath(_path, root = relativeRoot) {
+  return path.isAbsolute(_path) ? _path : path.resolve(root, _path);
 };

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -32,10 +32,10 @@ module.exports = (config = {}) => {
   config = Object.assign({}, configDefaults, config);
 
   // Expand file system configuration paths relative to configuration root
-  config.fixturesDir = expandPath(config.fixturesDir);
-  config.capturesDir = expandPath(config.capturesDir);
-  config.httpsKeyPath = config.httpsKeyPath && expandPath(config.httpsKeyPath);
-  config.httpsCertPath = config.httpsCertPath && expandPath(config.httpsCertPath);
+  config.fixturesDir = expandPath(config.fixturesDir, config.root);
+  config.capturesDir = expandPath(config.capturesDir, config.root);
+  config.httpsKeyPath = config.httpsKeyPath && expandPath(config.httpsKeyPath, config.root);
+  config.httpsCertPath = config.httpsCertPath && expandPath(config.httpsCertPath, config.root);
 
   return config;
 };

--- a/packages/mockyeah/test/TestHelper.js
+++ b/packages/mockyeah/test/TestHelper.js
@@ -6,7 +6,12 @@ global.MOCKYEAH_ROOT = __dirname;
 global.MOCKYEAH_SUPPRESS_OUTPUT = true;
 global.MOCKYEAH_VERBOSE_OUTPUT = false;
 
-const mockyeah = require('..');
+const Server = require('../server');
+
+const mockyeah = new Server({
+  root: __dirname
+});
+
 const request = require('supertest');
 
 const configHttps = Object.assign({}, mockyeah.config, {
@@ -14,7 +19,7 @@ const configHttps = Object.assign({}, mockyeah.config, {
   portHttps: 4443,
   adminPort: 4773
 });
-const mockyeahHttps = new mockyeah.Server(configHttps);
+const mockyeahHttps = new Server(configHttps);
 
 after(() => {
   mockyeah.close();

--- a/packages/mockyeah/test/integration/ConfigTest.js
+++ b/packages/mockyeah/test/integration/ConfigTest.js
@@ -9,6 +9,7 @@ describe('Config', () => {
   it('should work without config', function(done) {
     exec(
       `echo "
+      global.MOCKYEAH_ROOT = '~';
       const mockyeah = require('./index');
       setTimeout(() => {
         process.exit();

--- a/packages/mockyeah/test/integration/WatchTest.js
+++ b/packages/mockyeah/test/integration/WatchTest.js
@@ -8,6 +8,8 @@ const supertest = require('supertest');
 const watchedSuiteDir = `${__dirname}/../mockyeah/test-some-custom-capture`;
 const watchedSuiteFile = `${watchedSuiteDir}/index.js`;
 
+const root = `${__dirname}/../`;
+
 describe('Watcher Test', () => {
   beforeEach(() => {
     // eslint-disable-next-line no-sync
@@ -22,7 +24,7 @@ describe('Watcher Test', () => {
   it('should watch programmatically', function(done) {
     this.timeout(10000);
 
-    const mockyeah = new MockYeahServer({ port: 0, adminPort: 0 });
+    const mockyeah = new MockYeahServer({ port: 0, adminPort: 0, root });
 
     mockyeah.playAll();
     mockyeah.watch();
@@ -60,7 +62,7 @@ describe('Watcher Test', () => {
   it('should watch based on config', function(done) {
     this.timeout(10000);
 
-    const mockyeah = new MockYeahServer({ port: 0, adminPort: 0, watch: true });
+    const mockyeah = new MockYeahServer({ port: 0, adminPort: 0, root, watch: true });
 
     mockyeah.playAll();
 


### PR DESCRIPTION
The mockyeah root isn't working right in all scenarios. The environment variable and process global aren't flexible enough to support different tests since the `require` cache won't allow us to change them in some cases. We'll allow an optional config option `root` that overrides this when passed to `expandPath`.