### PR TITLE
docs: update suite example to new format

### DIFF
--- a/packages/mockyeah-docs/book/API/play.md
+++ b/packages/mockyeah-docs/book/API/play.md
@@ -11,23 +11,20 @@ This behavior may be changed by altering the values in the snapshot files.
 
 Here is an example of a service snapshot file:
 
-```json
-{
-  "method": "GET",
-  "url": "http://example.com/some/service",
-  "path": "/some/service",
-  "options": {
-    "headers": {
-      "x-powered-by": "Express",
-      "content-type": "text/plain; charset=utf-8",
-      "content-length": "12",
-      "etag": "W/\"5-iwTV43ddKY54RV78XKQE1Q\"",
-      "date": "Sun, 21 Feb 2016 06:17:49 GMT",
-      "connection": "close"
-    },
-    "status": 200,
-    "raw": "Hello world!",
-    "latency": 57
-  }
-}
+```js
+module.exports = [
+  [
+    "http://example.com/some/service",
+    {
+      headers: {
+        "x-powered-by": "Express",
+        "content-type": "text/plain; charset=utf-8",
+        "content-length": "12"
+      },
+      status: 200,
+      raw: "Hello world!",
+      latency: 57
+    }
+  ]
+];
 ```


### PR DESCRIPTION
We were using the old suite format in the docs here.