### PR TITLE
docs: remove unsupported reset specific routes

### DIFF
--- a/packages/mockyeah-docs/book/API/reset.md
+++ b/packages/mockyeah-docs/book/API/reset.md
@@ -6,14 +6,3 @@ Removes all mounted mock services. Best practice is to execute `.reset()` in an 
 // unmounts all mounted services after each test
 afterEach(() => mockyeah.reset());
 ```
-
-You may remove specific services by passing paths matching services to unmount. Example:
-
-```js
-mockyeah.get("/foo-1", { text: "bar" });
-mockyeah.get("/foo-2", { text: "bar" });
-mockyeah.get("/foo-3", { text: "bar" });
-
-// unmounts only /foo-1 and /foo-2
-mockyeah.reset("/foo-1", "/bar-2");
-```


### PR DESCRIPTION
We no longer support calling `reset` with specific routes to unmount them (since `0.15.9`), but we forgot to remove that from the docs here.