### PR TITLE
feat: record groups

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -14,7 +14,7 @@ const request = require('request');
 const querystring = require('querystring');
 
 // TODO: write tests for this
-const collect = (val, memo) => {
+const collectHeaders = (val, memo) => {
   const pair = val.split(/\s*:\s*/);
   const key = pair[0];
   const value = pair[1];
@@ -22,14 +22,17 @@ const collect = (val, memo) => {
   return memo;
 };
 
+const collectArray = (val, memo = []) => [...memo, ...val.split(',').map(v => v.trim())];
+
 program
+  .option('-g, --groups [name]', 'record with these named groups from configuration', collectArray)
   .option('-o, --only <regex>', 'only record calls to URLs matching given regex pattern')
   .option('-h, --use-headers', 'record headers to response options')
   .option('-l, --use-latency', 'record latency to response options')
   .option(
     '-H, --header <line>',
     'record matches will require these headers ("Name: Value")',
-    collect,
+    collectHeaders,
     {}
   )
   .option('-v, --verbose', 'verbose output')
@@ -85,11 +88,12 @@ global.MOCKYEAH_VERBOSE_OUTPUT = Boolean(program.verbose);
 
 boot(env => {
   const [name] = program.args;
-  const { only, header, useHeaders, useLatency } = program;
+  const { groups, only, header, useHeaders, useLatency } = program;
 
   env.program = program;
 
   const options = {
+    groups,
     only,
     headers: header,
     useHeaders,

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -73,12 +73,12 @@ const replaceFixtureWithRequireInJson = (json, { relativePath }) =>
     `"json"$1:$2require("${relativePath}/$3.json")`
   );
 
-const getDataForRecordToFixtures = ({ responseOptions, name, index }) => {
+const getDataForRecordToFixtures = ({ responseOptions, name, index, group }) => {
   const newResponseOptions = Object.assign({}, responseOptions);
 
   const { raw, json } = responseOptions;
 
-  const fixtureName = `${name}/${index}`;
+  const fixtureName = `${group && group.directory ? `${group.directory}/` : ''}${name}/${index}`;
 
   let body;
 

--- a/packages/mockyeah/app/lib/proxyRecord.js
+++ b/packages/mockyeah/app/lib/proxyRecord.js
@@ -4,9 +4,16 @@ const { handleContentType } = require('./helpers');
 const proxyRecord = ({ app, req, res, reqUrl, startTime, body }) => {
   const { recordMeta } = app.locals;
 
-  const { options: { headers: optionsHeaders, only, useHeaders, useLatency } = {} } = recordMeta;
+  const {
+    options: { headers: optionsHeaders, only, useHeaders, useLatency, groups } = {}
+  } = recordMeta;
 
-  if (only && !only(reqUrl)) return;
+  if (!groups && only && !only.test(reqUrl)) return;
+
+  let group;
+  if (groups) {
+    group = groups.find(g => g.test(reqUrl));
+  }
 
   const { method, body: reqBody } = req;
 
@@ -59,7 +66,13 @@ const proxyRecord = ({ app, req, res, reqUrl, startTime, body }) => {
     responseOptions.latency = latency;
   }
 
-  recordMeta.set.push([match, responseOptions]);
+  recordMeta.set.push([
+    match,
+    responseOptions,
+    {
+      group
+    }
+  ]);
 };
 
 module.exports = proxyRecord;

--- a/packages/mockyeah/app/makeAPI/makeRecordStop.js
+++ b/packages/mockyeah/app/makeAPI/makeRecordStop.js
@@ -32,8 +32,26 @@ const makeRecordStop = app => {
 
     const filePath = resolveFilePath(suitePath, 'index.js');
 
-    const newSet = set.map((suite, index) => {
-      const [match, responseOptions] = suite;
+    let i = 0;
+    const indexByDirectory = {};
+
+    const newSet = set.map(suite => {
+      const [match, responseOptions, options = {}] = suite;
+
+      const { group } = options;
+
+      const { directory } = group || {};
+
+      let index;
+      if (directory) {
+        index = indexByDirectory[directory] || 0;
+        indexByDirectory[directory] = indexByDirectory[directory]
+          ? indexByDirectory[directory] + 1
+          : 1;
+      } else {
+        index = i;
+        i += 1;
+      }
 
       app.log(['serve', 'suite'], match.url || match.path || match);
 
@@ -41,7 +59,8 @@ const makeRecordStop = app => {
         const { newResponseOptions, body } = getDataForRecordToFixtures({
           responseOptions,
           name,
-          index
+          index,
+          group
         });
 
         const { fixture } = newResponseOptions;
@@ -51,7 +70,7 @@ const makeRecordStop = app => {
 
           // TODO: Any easy way to coordinate this asynchronously?
           // eslint-disable-next-line no-sync
-          mkdirp.sync(path.join(fixturesDir, name));
+          mkdirp.sync(path.resolve(fixturesPath, '..'));
 
           // TODO: Any easy way to coordinate this asynchronously?
           // eslint-disable-next-line no-sync

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -22,7 +22,8 @@ const configDefaults = {
   recordToFixturesMode: 'path',
   formatScript: undefined,
   watch: false,
-  responseHeaders: true
+  responseHeaders: true,
+  groups: {}
 };
 
 module.exports = (config = {}) => {

--- a/packages/mockyeah/test/integration/RecordGroupsTest.js
+++ b/packages/mockyeah/test/integration/RecordGroupsTest.js
@@ -1,0 +1,189 @@
+'use strict';
+
+/* eslint-disable no-sync */
+
+const fs = require('fs');
+const path = require('path');
+const async = require('async');
+const supertest = require('supertest');
+const rimraf = require('rimraf');
+const MockYeahServer = require('../../server');
+const { expect } = require('chai');
+
+const ROOT = path.resolve(__dirname, '../.tmp/proxy');
+
+describe('Record Groups Test', function() {
+  let proxy;
+  let remote;
+  let proxyReq;
+  let remoteReq;
+
+  before(done => {
+    async.parallel(
+      [
+        function(cb) {
+          // Instantiate proxy server for recording
+          proxy = MockYeahServer(
+            {
+              name: 'proxy',
+              port: 0,
+              adminPort: 0,
+              root: ROOT,
+              groups: {
+                someService: {
+                  pattern: 'some/service',
+                  directory: true
+                },
+                someServiceNamedDir: {
+                  pattern: 'some/named-dir/service',
+                  directory: 'someServiceDirectoryForNamedDir'
+                },
+                someNonSubdirGroup: 'some/non-subdir/service',
+                unusedGroup: 'unused'
+              }
+            },
+            cb
+          );
+        },
+        function(cb) {
+          // Instantiate remote server
+          remote = MockYeahServer(
+            {
+              name: 'remote',
+              port: 0,
+              adminPort: 0
+            },
+            cb
+          );
+        }
+      ],
+      () => {
+        remoteReq = supertest(remote.server);
+        proxyReq = supertest(`${proxy.server.rootUrl}/${remote.server.rootUrl}`);
+        done();
+      }
+    );
+  });
+
+  afterEach(() => {
+    proxy.reset();
+    remote.reset();
+    rimraf.sync(ROOT);
+  });
+
+  after(() => {
+    proxy.close();
+    remote.close();
+  });
+
+  function getSuiteFilePath(suiteName) {
+    return path.resolve(ROOT, 'mockyeah', suiteName, 'index.js');
+  }
+
+  function getFixtureFilePath(suiteName, groupName = '.') {
+    return path.resolve(ROOT, 'fixtures', groupName, suiteName, '0.txt');
+  }
+
+  it('should record fixture to group subdirectory', function(done) {
+    this.timeout = 10000;
+
+    const suiteName = 'test-some-fancy-suite-group-file';
+
+    // Construct remote service urls
+    // e.g. http://localhost:4041/http://example.com/some/service
+    const path1 = '/some/service/one';
+    const path2 = '/some/non-subdir/service/two';
+    const path3 = '/some/named-dir/service/three';
+
+    // Mount remote service end points
+    remote.get(path1, { text: 'hey there' });
+    remote.get(path2, { text: 'hey non-subdir there' });
+    remote.get(path3, { text: 'hey named dir there' });
+
+    // Initiate recording and playback series
+    async.series(
+      [
+        // Initiate recording
+        cb => {
+          proxy.record(suiteName, {
+            groups: [
+              'someService',
+              'someNonSubdirGroup',
+              'someServiceNamedDir',
+              'unknownGroupSpecified'
+            ]
+          });
+          cb();
+        },
+
+        // Invoke requests to remote services through proxy
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => proxyReq.get(path1).expect(200, cb),
+        cb => proxyReq.get(path2).expect(200, cb),
+        cb => proxyReq.get(path3).expect(200, cb),
+
+        // Stop recording
+        cb => {
+          proxy.recordStop(cb);
+        },
+
+        // // Assert fixture file exists
+        cb => {
+          const contents = fs.readFileSync(getFixtureFilePath(suiteName, 'someService'), 'utf8');
+          expect(contents).to.equal('hey there');
+          cb();
+        },
+
+        // // Assert fixture file exists
+        cb => {
+          const contents = fs.readFileSync(getFixtureFilePath(suiteName), 'utf8');
+          expect(contents).to.equal('hey non-subdir there');
+          cb();
+        },
+
+        // // Assert fixture file exists
+        cb => {
+          const contents = fs.readFileSync(
+            getFixtureFilePath(suiteName, 'someServiceDirectoryForNamedDir'),
+            'utf8'
+          );
+          expect(contents).to.equal('hey named dir there');
+          cb();
+        },
+
+        // Assert suite file exists
+        cb => {
+          const contents = fs.readFileSync(getSuiteFilePath(suiteName), 'utf8');
+          expect(contents).to.contain(
+            '"fixture": "someService/test-some-fancy-suite-group-file/0.txt"'
+          );
+          expect(contents).to.contain(
+            '"fixture": "someServiceDirectoryForNamedDir/test-some-fancy-suite-group-file/0.txt"'
+          );
+          expect(contents).to.contain('"fixture": "test-some-fancy-suite-group-file/0.txt"');
+          cb();
+        },
+
+        // Reset proxy services and play recorded suite
+        cb => {
+          proxy.reset();
+          cb();
+        },
+
+        cb => {
+          proxy.play(suiteName);
+          cb();
+        },
+
+        // Test remote url paths and their sub paths route to the same services
+        // Assert remote url paths are routed the correct responses
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => remoteReq.get(path1).expect(200, cb),
+
+        // Assert paths are routed the correct responses
+        cb => proxyReq.get(path1).expect(200, cb)
+      ],
+      done
+    );
+  });
+});

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -43,7 +43,8 @@ describe('prepareConfig', () => {
       recordToFixturesMode: 'path',
       formatScript: undefined,
       watch: false,
-      responseHeaders: true
+      responseHeaders: true,
+      groups: {}
     });
   });
 
@@ -70,7 +71,8 @@ describe('prepareConfig', () => {
       recordToFixturesMode: 'path',
       formatScript: undefined,
       watch: false,
-      responseHeaders: true
+      responseHeaders: true,
+      groups: {}
     });
   });
 });


### PR DESCRIPTION
Fixes #252.

Also includes opt-in support to write fixtures matching specific group URL patterns to a top-level group sub-directory (at `fixtures/posts/suite-name` instead of `fixtures/suite-name`), e.g.:

```
{
  "groups": {
    "users": "/api/v(.*)/users",
    "posts": {
      pattern: "/api/v(.*)/posts",
      directory: "posts" // or 'true' to use group name
    }
  }
}
```

Will document in a future PR.
