### PR TITLE
fix: specify required CLI arguments

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -14,7 +14,7 @@ const request = require('request');
 const querystring = require('querystring');
 
 // TODO: write tests for this
-const collectHeaders = (val, memo) => {
+const collectHeaders = (val, memo = {}) => {
   const pair = val.split(/\s*:\s*/);
   const key = pair[0];
   const value = pair[1];
@@ -26,14 +26,13 @@ const collectArray = (val, memo = []) => [...memo, ...val.split(',').map(v => v.
 
 program
   .option('-g, --groups [name]', 'record with these named groups from configuration', collectArray)
-  .option('-o, --only <regex>', 'only record calls to URLs matching given regex pattern')
+  .option('-o, --only [regex]', 'only record calls to URLs matching given regex pattern')
   .option('-h, --use-headers', 'record headers to response options')
   .option('-l, --use-latency', 'record latency to response options')
   .option(
-    '-H, --header <line>',
+    '-H, --header [line]',
     'record matches will require these headers ("Name: Value")',
-    collectHeaders,
-    {}
+    collectHeaders
   )
   .option('-v, --verbose', 'verbose output')
   .parse(process.argv);

--- a/packages/mockyeah-docs/book/CLI/CLI.md
+++ b/packages/mockyeah-docs/book/CLI/CLI.md
@@ -76,10 +76,11 @@ Usage: mockyeah-record [options]
 
   Options:
 
-    -o, --only <regex>   only record calls to URLs matching given regex pattern
+    -g, --groups [name]  record with these named groups from configuration
+    -o, --only [regex]   only record calls to URLs matching given regex pattern
     -h, --use-headers    record headers to response options
     -l, --use-latency    record latency to response options
-    -H, --header <line>  record matches will require these headers ("Name: Value") (default: [object Object])
+    -H, --header [line]  record matches will require these headers ("Name: Value")
     -v, --verbose        verbose output
     -h, --help           output usage information
 ```


### PR DESCRIPTION
We were using the optional argument syntax for some required arguments with the CLI via `commander`.