### PR TITLE
feat: support multiple --only

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -22,16 +22,26 @@ const collectHeaders = (val, memo = {}) => {
   return memo;
 };
 
-const collectArray = (val, memo = []) => [...memo, ...val.split(',').map(v => v.trim())];
+const collectCommaSeparated = (val, memo = []) => [...memo, ...val.split(',').map(v => v.trim())];
+
+const collect = (val, memo = []) => [...memo, val.trim()];
 
 program
-  .option('-g, --groups [name]', 'record with these named groups from configuration', collectArray)
-  .option('-o, --only [regex]', 'only record calls to URLs matching given regex pattern')
+  .option(
+    '-g, --groups [name]',
+    'record with these named groups from configuration (comma-separated and/or repeatable)',
+    collectCommaSeparated
+  )
+  .option(
+    '-o, --only [regex]',
+    'only record calls to URLs matching given regex pattern (repeatable)',
+    collect
+  )
   .option('-h, --use-headers', 'record headers to response options')
   .option('-l, --use-latency', 'record latency to response options')
   .option(
-    '-H, --header [line]',
-    'record matches will require these headers ("Name: Value")',
+    '-H, --header [pair]',
+    'record matches will require these headers ("Name: Value") (repeatable)',
     collectHeaders
   )
   .option('-v, --verbose', 'verbose output')

--- a/packages/mockyeah-docs/book/CLI/CLI.md
+++ b/packages/mockyeah-docs/book/CLI/CLI.md
@@ -76,11 +76,11 @@ Usage: mockyeah-record [options]
 
   Options:
 
-    -g, --groups [name]  record with these named groups from configuration
-    -o, --only [regex]   only record calls to URLs matching given regex pattern
+    -g, --groups [name]  record with these named groups from configuration (comma-separated and/or repeatable)
+    -o, --only [regex]   only record calls to URLs matching given regex pattern (repeatable)
     -h, --use-headers    record headers to response options
     -l, --use-latency    record latency to response options
-    -H, --header [line]  record matches will require these headers ("Name: Value")
+    -H, --header [pair]  record matches will require these headers ("Name: Value") (repeatable)
     -v, --verbose        verbose output
     -h, --help           output usage information
 ```

--- a/packages/mockyeah/app/lib/proxyRecord.js
+++ b/packages/mockyeah/app/lib/proxyRecord.js
@@ -8,7 +8,7 @@ const proxyRecord = ({ app, req, res, reqUrl, startTime, body }) => {
     options: { headers: optionsHeaders, only, useHeaders, useLatency, groups } = {}
   } = recordMeta;
 
-  if (!groups && only && !only.test(reqUrl)) return;
+  if (!groups && only && !only.some(o => o.test(reqUrl))) return;
 
   let group;
   if (groups) {

--- a/packages/mockyeah/app/makeAPI/makeRecord.js
+++ b/packages/mockyeah/app/makeAPI/makeRecord.js
@@ -1,21 +1,27 @@
 const makeRecord = app => {
   const record = (name, options = {}) => {
-    let only;
     let groups;
 
     app.locals.recording = true;
 
     if (!name) throw new Error('Must provide a recording name.');
+
     app.log(['serve', 'record'], name);
 
-    if (options.only && typeof options.only === 'string') {
-      // if only is truthy, assume it is a regex pattern
-      const regex = new RegExp(options.only);
-      only = {
-        test: regex.test.bind(regex)
-      };
-      app.log(['serve', 'record', 'only'], regex);
-    }
+    const only =
+      options.only &&
+      (Array.isArray(options.only) ? options.only : [options.only]).map(o => {
+        app.log(['serve', 'record', 'only'], o);
+
+        // if only is truthy, assume it is a regex pattern
+        const regex = new RegExp(o);
+
+        const obj = {
+          test: regex.test.bind(regex)
+        };
+
+        return obj;
+      });
 
     // array of strings
     if (options.groups) {

--- a/packages/mockyeah/test/integration/RecordAndPlayTest.js
+++ b/packages/mockyeah/test/integration/RecordAndPlayTest.js
@@ -201,7 +201,7 @@ describe('Record and Playback', function() {
       [
         // Initiate recording
         cb => {
-          proxy.record(suiteName, { only: '.*three.*' });
+          proxy.record(suiteName, { only: ['.*three.*', 'madeup'] });
           cb();
         },
 


### PR DESCRIPTION
Simply allows passing multiple `--only` flags to the CLI, or as an array programmatically. They are combined such that matching any one is enough to match for recording (an "or" join). Fixes #275.