### PR TITLE
refactor: route handler

### DIFF
--- a/packages/mockyeah/app/lib/RouteResolver.js
+++ b/packages/mockyeah/app/lib/RouteResolver.js
@@ -64,7 +64,7 @@ function listen() {
         }
       }
 
-      route.response(req, res);
+      route.response(app, req, res);
     };
 
     route.expectation.middleware(req, res, expectationNext);

--- a/packages/mockyeah/app/lib/handleDynamicSuite.js
+++ b/packages/mockyeah/app/lib/handleDynamicSuite.js
@@ -27,7 +27,7 @@ const handleDynamicSuite = (app, req, res) => {
 
   if (!route) return false;
 
-  compiledRoute.response(req, res);
+  compiledRoute.response(app, req, res);
 
   return true;
 };

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -9,7 +9,7 @@ const {
   encodedPortRegex,
   encodedProtocolRegex
 } = require('./constants');
-const routeHandler = require('./routeHandler');
+const makeRouteHandler = require('./makeRouteHandler');
 
 const isPromise = value => value && (value instanceof Promise || !!(value.then && value.catch));
 
@@ -157,8 +157,13 @@ const compileRoute = (app, match, response) => {
     response
   };
 
-  if (!_.isFunction(route.response)) {
-    route.response = routeHandler(app, route);
+  if (!_.isFunction(response)) {
+    route.response = makeRouteHandler(route);
+  } else {
+    const routeHandler = (_app, req, res, next) => {
+      return response(req, res, next);
+    };
+    route.response = routeHandler;
   }
 
   if (!_.isPlainObject(match)) {

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -160,9 +160,7 @@ const compileRoute = (app, match, response) => {
   if (!_.isFunction(response)) {
     route.response = makeRouteHandler(route);
   } else {
-    const routeHandler = (_app, req, res, next) => {
-      return response(req, res, next);
-    };
+    const routeHandler = (_app, req, res, next) => response(req, res, next);
     route.response = routeHandler;
   }
 

--- a/packages/mockyeah/app/lib/makeRouteHandler.js
+++ b/packages/mockyeah/app/lib/makeRouteHandler.js
@@ -107,12 +107,12 @@ function verifyFile(app, filePath, message) {
   });
 }
 
-module.exports = function handler(app, route) {
+const makeRouteHandler = route => {
   const response = route.response || {};
 
   validateResponse(response);
 
-  return (req, res, next) => {
+  function routeHandler(app, req, res, next) {
     const start = new Date().getTime();
     let send;
 
@@ -193,5 +193,9 @@ module.exports = function handler(app, route) {
       send();
       app.log(['request', req.method], `${req.url} (${duration}ms)`);
     }, response.latency);
-  };
+  }
+
+  return routeHandler;
 };
+
+module.exports = makeRouteHandler;


### PR DESCRIPTION
Refactors the route handler so it doesn't need an `app` argument when defining - changes that to be passed as runtime. This is a step toward removing `app` from `compileRoute`, which will later support #282.