### PR TITLE
refactor: compile route doesn't need app

### DIFF
--- a/packages/mockyeah/app/lib/RouteResolver.js
+++ b/packages/mockyeah/app/lib/RouteResolver.js
@@ -92,7 +92,7 @@ RouteResolver.prototype.register = function register(method, _path, response) {
         path: _path
       };
 
-  const route = compileRoute(this.app, match, response);
+  const route = compileRoute(match, response);
 
   const expectation = new Expectation(route);
   route.expectation = expectation;

--- a/packages/mockyeah/app/lib/handleDynamicSuite.js
+++ b/packages/mockyeah/app/lib/handleDynamicSuite.js
@@ -18,7 +18,7 @@ const handleDynamicSuite = (app, req, res) => {
   let compiledRoute;
 
   const route = suite.find(r => {
-    compiledRoute = compileRoute(app, r[0], r[1]);
+    compiledRoute = compileRoute(r[0], r[1]);
 
     return routeMatchesRequest(compiledRoute, req, {
       aliases

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -151,7 +151,7 @@ const handlePathTypes = (_path, _query) => {
   throw new Error(`Unsupported path type ${typeof _path}: ${_path}`);
 };
 
-const compileRoute = (app, match, response) => {
+const compileRoute = (match, response) => {
   const route = {
     method: match.method || 'get',
     response

--- a/packages/mockyeah/test/unit/helpers.test.js
+++ b/packages/mockyeah/test/unit/helpers.test.js
@@ -45,27 +45,24 @@ describe('app helpers', () => {
 
   describe('compileRoute', () => {
     it('works for strings', () => {
-      const app = {};
       const match = '/';
-      expect(compileRoute(app, match).path).to.equal('/');
+      expect(compileRoute(match).path).to.equal('/');
     });
 
     it('works for objects without method', () => {
-      const app = {};
       const match = {
         path: '/'
       };
-      expect(compileRoute(app, match).path).to.equal('/');
+      expect(compileRoute(match).path).to.equal('/');
     });
 
     it('works for objects with method', () => {
-      const app = {};
       const match = {
         method: 'post',
         path: '/'
       };
-      expect(compileRoute(app, match).method).to.equal('post');
-      expect(compileRoute(app, match).path).to.equal('/');
+      expect(compileRoute(match).method).to.equal('post');
+      expect(compileRoute(match).path).to.equal('/');
     });
   });
 


### PR DESCRIPTION
Since we refactored in #286, we don't need to pass `app` to `compileRoute` anymore. This will later support #282.