### PR TITLE
refactor: use matches for route-request matching

### DIFF
--- a/packages/mockyeah/app/lib/matches.js
+++ b/packages/mockyeah/app/lib/matches.js
@@ -9,7 +9,7 @@ const stringify = value => {
   }
 };
 
-const makeMatcher = () => {
+const makeMatcher = ({ shortCircuit } = {}) => {
   const errors = [];
 
   const matcher = (value, source, keyPath = []) => {
@@ -46,8 +46,9 @@ const makeMatcher = () => {
           keyPath
         });
       }
-    } else if (isObject(value)) {
+    } else if (isObject(value) && isObject(source)) {
       Object.keys(source).forEach(key => {
+        if (shortCircuit && errors.length) return;
         matcher(value[key], source[key], [...keyPath, key]);
       });
     } else {
@@ -63,10 +64,12 @@ const makeMatcher = () => {
   return { errors, matcher };
 };
 
-const matches = (object, source) => {
-  const { errors, matcher } = makeMatcher();
+const matches = (value, source, { shortCircuit } = {}) => {
+  const { errors, matcher } = makeMatcher({
+    shortCircuit
+  });
 
-  matcher(object, source);
+  matcher(value, source);
 
   const result = !errors.length;
 

--- a/packages/mockyeah/test/unit/matches.test.js
+++ b/packages/mockyeah/test/unit/matches.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const matches = require('../../app/lib/matches');
+
+describe('matches', () => {
+  it('reports all deep errors by default', () => {
+    const match = matches(
+      {
+        a: 1,
+        b: 2,
+        c: {
+          d: 3,
+          e: 4,
+          f: 5
+        }
+      },
+      {
+        a: 1,
+        c: {
+          d: 0,
+          e: 4,
+          f: 9
+        }
+      }
+    );
+
+    expect(match.errors).to.have.length(2);
+  });
+
+  it('short circuits if specified', () => {
+    const match = matches(
+      {
+        a: 1,
+        b: 2
+      },
+      {
+        c: 1,
+        d: 2
+      },
+      {
+        shortCircuit: true
+      }
+    );
+
+    expect(match.errors).to.have.length(1);
+  });
+});


### PR DESCRIPTION
Refactors the route request matching to use `matches` (with new short-circuit option). This decouples it from the Express request schema, in support of #282.