### PR TITLE
feat: use debug as logger

### DIFF
--- a/packages/mockyeah/app/lib/Logger.js
+++ b/packages/mockyeah/app/lib/Logger.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const defaultDebug = value => value || 'mockyeah:*';
+
+if (typeof process !== 'undefined') {
+  process.env.DEBUG = defaultDebug(process.env.DEBUG);
+} else {
+  global.DEBUG = defaultDebug(global.DEBUG);
+}
+
+const debug = require('debug');
+
 /* eslint-disable no-console, prefer-destructuring */
 
 /**
@@ -32,6 +42,7 @@ function prepareArguments(/* [type=INFO], message, [verbose=true] */) {
     args.message = arguments[1];
     args.verbose = arguments[2];
   } else if (arguments.length === 2 && typeof arguments[1] === 'boolean') {
+    args.types = ['info'];
     args.message = arguments[0];
     args.verbose = arguments[1];
   } else if (arguments.length === 2) {
@@ -39,13 +50,8 @@ function prepareArguments(/* [type=INFO], message, [verbose=true] */) {
     args.message = arguments[1];
   }
 
-  args.types = args.types || 'info';
   // Coerce types string to array
   args.types = Array.isArray(args.types) ? args.types : [args.types];
-
-  // If verbose value is not passed, message should always output
-  args.always = args.verbose === undefined;
-  args.verbose = Boolean(args.verbose);
 
   return args;
 }
@@ -73,12 +79,15 @@ Logger.prototype.log = function log(/* [type=INFO], message, [verbose=true] */) 
   if (args.verbose) args.types.unshift('verbose');
 
   // Add timestamp to message
-  args.types.unshift(new Date().toLocaleTimeString('en-US', { hour12: false }));
+  const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
 
-  // Prepare string of types for output
-  args.types = args.types.reduce((result, value) => `${result}[${value.toUpperCase()}]`, '');
+  const logTypesDebugMessage = args.types.map(type => type.toLowerCase()).join(':');
 
-  console.log(`[${this.name}]${args.types} ${args.message}`);
+  const log = debug(`${this.name}:${logTypesDebugMessage}`);
+
+  log.log = console.log.bind(console);
+
+  log(`[${timestamp}] ${args.message}`);
 };
 
 module.exports = Logger;

--- a/packages/mockyeah/app/lib/Logger.js
+++ b/packages/mockyeah/app/lib/Logger.js
@@ -2,11 +2,8 @@
 
 const defaultDebug = value => value || 'mockyeah:*';
 
-if (typeof process !== 'undefined') {
-  process.env.DEBUG = defaultDebug(process.env.DEBUG);
-} else {
-  global.DEBUG = defaultDebug(global.DEBUG);
-}
+// TODO: Support browser.
+process.env.DEBUG = defaultDebug(process.env.DEBUG);
 
 const debug = require('debug');
 
@@ -83,11 +80,11 @@ Logger.prototype.log = function log(/* [type=INFO], message, [verbose=true] */) 
 
   const logTypesDebugMessage = args.types.map(type => type.toLowerCase()).join(':');
 
-  const log = debug(`${this.name}:${logTypesDebugMessage}`);
+  const debugLog = debug(`${this.name}:${logTypesDebugMessage}`);
 
-  log.log = console.log.bind(console);
+  debugLog.log = console.log.bind(console);
 
-  log(`[${timestamp}] ${args.message}`);
+  debugLog(`[${timestamp}] ${args.message}`);
 };
 
 module.exports = Logger;

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -78,6 +78,7 @@
     "cors": "^2.7.1",
     "cosmiconfig": "^5.0.7",
     "create-cert-files": "^1.0.2",
+    "debug": "^4.1.1",
     "express": "^4.13.3",
     "is-absolute-url": "^2.1.0",
     "lodash": "^4.17.5",

--- a/packages/mockyeah/server/index.js
+++ b/packages/mockyeah/server/index.js
@@ -21,6 +21,8 @@ module.exports = function Server(config, onStart) {
   // Instantiate an application
   const app = new App(config);
 
+  app.log('initialized', false);
+
   // Enable CORS for all routes
   app.use(cors());
 

--- a/packages/mockyeah/test/integration/ConfigTest.js
+++ b/packages/mockyeah/test/integration/ConfigTest.js
@@ -5,12 +5,14 @@
 const { exec } = require('child_process');
 const { expect } = require('chai');
 
+const ROOT = `${__dirname}/../..`;
+
 describe('Config', () => {
   it('should work without config', function(done) {
     exec(
       `echo "
       global.MOCKYEAH_ROOT = '~';
-      const mockyeah = require('./index');
+      const mockyeah = require('${ROOT}/index');
       setTimeout(() => {
         process.exit();
       }, 1000)
@@ -25,7 +27,7 @@ describe('Config', () => {
   it('should write output to stdout by default', function(done) {
     exec(
       `echo "
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0 }, function() { process.exit() });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0 }, function() { process.exit() });
       " | node`,
       function(err, stdout) {
         expect(stdout).to.include('mockyeah');
@@ -37,7 +39,7 @@ describe('Config', () => {
   it('should write output to stdout when enabled', function(done) {
     exec(
       `echo "
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0, output: true }, function() { process.exit() });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0, output: true }, function() { process.exit() });
       " | node`,
       function(err, stdout) {
         expect(stdout).to.include('mockyeah');
@@ -49,7 +51,7 @@ describe('Config', () => {
   it('should not write to stdout when disabled', function(done) {
     exec(
       `echo "
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0, output: false }, function() { process.exit() });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0, output: false }, function() { process.exit() });
       " | node`,
       function(err, stdout) {
         expect(stdout).to.not.include('mockyeah');
@@ -62,7 +64,7 @@ describe('Config', () => {
     exec(
       `echo "
       const request = require('supertest');
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0 });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0 });
       mockyeah.get('/foo', { text: 'bar' });
       request(mockyeah.server)
       .get('/foo?bar=true')
@@ -79,7 +81,7 @@ describe('Config', () => {
     exec(
       `echo "
       const request = require('supertest');
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0, verbose: true });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0, verbose: true });
       mockyeah.get('/foo', { text: 'bar' });
       request(mockyeah.server)
       .get('/foo?bar=true')
@@ -96,7 +98,7 @@ describe('Config', () => {
     exec(
       `echo "
       const request = require('supertest');
-      const mockyeah = require('./index');
+      const mockyeah = require('${ROOT}/index');
       setTimeout(function() {
         mockyeah.get('/foo', { text: 'bar' });
         request(mockyeah.server)
@@ -115,14 +117,14 @@ describe('Config', () => {
     exec(
       `echo "
       const request = require('supertest');
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0 });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0 });
       mockyeah.get('/foo', { text: 'bar' });
       request(mockyeah.server)
         .get('/foo?bar=true')
         .expect(200, /bar/, process.exit);
       " | node`,
       function(err, stdout) {
-        expect(stdout).to.not.include('JOURNAL');
+        expect(stdout).to.not.include('journal');
         done();
       }
     );
@@ -132,14 +134,14 @@ describe('Config', () => {
     exec(
       `echo "
       const request = require('supertest');
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0, journal: true });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0, journal: true });
       mockyeah.get('/foo', { text: 'bar' });
       request(mockyeah.server)
         .get('/foo?bar=true')
         .expect(200, /bar/, process.exit);
       " | node`,
       function(err, stdout) {
-        expect(stdout).to.include('JOURNAL');
+        expect(stdout).to.include('journal');
         done();
       }
     );
@@ -149,14 +151,14 @@ describe('Config', () => {
     exec(
       `echo "
       const request = require('supertest');
-      const mockyeah = new require('./server')({ port: 0, adminPort: 0, journal: false });
+      const mockyeah = new require('${ROOT}/server')({ port: 0, adminPort: 0, journal: false });
       mockyeah.get('/foo', { text: 'bar' });
       request(mockyeah.server)
         .get('/foo?bar=true')
         .expect(200, /bar/, process.exit);
       " | node`,
       function(err, stdout) {
-        expect(stdout).to.not.include('JOURNAL');
+        expect(stdout).to.not.include('journal');
         done();
       }
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -654,10 +654,6 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
-ansi-regex@*:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -2024,13 +2020,19 @@ debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  dependencies:
+    ms "^2.1.1"
+
 debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -3974,7 +3976,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -4790,10 +4792,6 @@ lodash._baseflatten@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash._baseflatten/-/lodash._baseflatten-4.2.1.tgz#54acad5e6ef53532a5b8269c0ad725470cfd9208"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4801,25 +4799,11 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -4896,10 +4880,6 @@ lodash.padstart@^4.1.0:
 lodash.rest@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/lodash.rest/-/lodash.rest-4.0.5.tgz#954ef75049262038c96d1fc98b28fdaf9f0772aa"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -5419,7 +5399,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.0.0:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -7174,7 +7154,7 @@ readable-stream@~2.1.2, readable-stream@~2.1.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -8653,7 +8633,7 @@ v8flags@^2.0.11:
   dependencies:
     user-home "^1.1.1"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:


### PR DESCRIPTION
Switching from `console.log` to [`debug`](https://www.npmjs.com/package/debug) in our logger module. This library is a de facto standard for Node libraries and applications (created by TJ Holowaychuk , used in Express, etc.). It supports configuring which logs are shown via a `DEBUG` environment variable, so that users can opt in or out of various levels of logging granularity, or only monitor logs relating to particular feature(s). On a TTY terminal, it gives each type of log a different color for prettier and more readable output. It also works in the browser with `DEBUG` global (which may come in handy for #282).

For now, we still support all existing options including `output`, `verbose`, and `journal`.

We default to showing all `mockyeah*` log output if `DEBUG` is not defined.

Example from tests:

<img width="609" alt="screen shot 2019-03-07 at 7 16 05 am" src="https://user-images.githubusercontent.com/615381/53959365-15266800-40a9-11e9-9dda-1db52a1208e8.png">

May add documentation in a future PR.

Fixes #153.
