### PR TITLE
fix: safe filenames

### DIFF
--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -10,6 +10,7 @@ const {
   encodedProtocolRegex
 } = require('./constants');
 const makeRouteHandler = require('./makeRouteHandler');
+const safeFilename = require('../../lib/safeFilename');
 
 const isPromise = value => value && (value instanceof Promise || !!(value.then && value.catch));
 
@@ -78,7 +79,9 @@ const getDataForRecordToFixtures = ({ responseOptions, name, index, group }) => 
 
   const { raw, json } = responseOptions;
 
-  const fixtureName = `${group && group.directory ? `${group.directory}/` : ''}${name}/${index}`;
+  const fixtureName = safeFilename(
+    `${group && group.directory ? `${group.directory}/` : ''}${name}/${index}`
+  );
 
   let body;
 

--- a/packages/mockyeah/app/lib/makeRouteHandler.js
+++ b/packages/mockyeah/app/lib/makeRouteHandler.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const expandPath = require('../../lib/expandPath');
+const safeFilename = require('../../lib/safeFilename');
 
 /**
  *
@@ -109,6 +110,10 @@ function verifyFile(app, filePath, message) {
 
 const makeRouteHandler = route => {
   const response = route.response || {};
+
+  if (response.filePath) {
+    response.filePath = safeFilename(response.filePath);
+  }
 
   validateResponse(response);
 

--- a/packages/mockyeah/app/makeAPI/makeRecordStop.js
+++ b/packages/mockyeah/app/makeAPI/makeRecordStop.js
@@ -7,6 +7,7 @@ const {
   getDataForRecordToFixtures,
   replaceFixtureWithRequireInJson
 } = require('../lib/helpers');
+const safeFilename = require('../../lib/safeFilename');
 
 const makeRecordStop = app => {
   const recordStop = cb => {
@@ -26,7 +27,9 @@ const makeRecordStop = app => {
 
     const { suitesDir, fixturesDir } = app.config;
 
-    const suitePath = path.join(suitesDir, name);
+    const suiteFileame = safeFilename(name);
+
+    const suitePath = path.join(suitesDir, suiteFileame);
 
     mkdirp.sync(suitePath);
 

--- a/packages/mockyeah/lib/safeFilename.js
+++ b/packages/mockyeah/lib/safeFilename.js
@@ -1,0 +1,3 @@
+const safeFilename = filename => filename.replace(/^(\w+:)?[/\\]+/, '').replace(/\.\.[/\\]/g, '');
+
+module.exports = safeFilename;

--- a/packages/mockyeah/test/integration/RecordBadFilenameTest.js
+++ b/packages/mockyeah/test/integration/RecordBadFilenameTest.js
@@ -1,0 +1,144 @@
+'use strict';
+
+/* eslint-disable no-sync */
+
+const fs = require('fs');
+const path = require('path');
+const async = require('async');
+const supertest = require('supertest');
+const rimraf = require('rimraf');
+const MockYeahServer = require('../../server');
+const safeFilename = require('../../lib/safeFilename');
+
+const PROXY_SUITES_DIR = path.resolve(__dirname, '../.tmp/proxy/mockyeah');
+
+describe('Record and Playback Bad Filename', function() {
+  let proxy;
+  let remote;
+  let proxyReq;
+  let remoteReq;
+
+  before(done => {
+    async.parallel(
+      [
+        function(cb) {
+          // Instantiate proxy server for recording
+          proxy = MockYeahServer(
+            {
+              name: 'proxy',
+              port: 0,
+              adminPort: 0,
+              suitesDir: PROXY_SUITES_DIR
+            },
+            cb
+          );
+        },
+        function(cb) {
+          // Instantiate remote server
+          remote = MockYeahServer(
+            {
+              name: 'remote',
+              port: 0,
+              adminPort: 0
+            },
+            cb
+          );
+        }
+      ],
+      () => {
+        remoteReq = supertest(remote.server);
+        proxyReq = supertest(`${proxy.server.rootUrl}/${remote.server.rootUrl}`);
+        done();
+      }
+    );
+  });
+
+  afterEach(() => {
+    proxy.reset();
+    remote.reset();
+    rimraf.sync(PROXY_SUITES_DIR);
+  });
+
+  after(() => {
+    proxy.close();
+    remote.close();
+  });
+
+  function getSuiteFilePath(suiteName) {
+    return path.resolve(PROXY_SUITES_DIR, safeFilename(suiteName), 'index.js');
+  }
+
+  it('should record and playback bad filename', function(done) {
+    this.timeout = 10000;
+
+    const suiteName = '../test-bad-filename-suite';
+
+    // Construct remote service urls
+    // e.g. http://localhost:4041/http://example.com/some/service
+    const path1 = '/some/service/one';
+
+    // Mount remote service end points
+    remote.get('/some/service/one', { text: 'first' });
+
+    // Initiate recording and playback series
+    async.series(
+      [
+        // Initiate recording
+        cb => {
+          proxy.record(suiteName);
+          cb();
+        },
+
+        // Invoke requests to remote services through proxy
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => proxyReq.get(path1).expect(200, 'first', cb),
+
+        // Stop recording but pretend there's a file write error.
+        cb => {
+          const { writeFile } = fs;
+          fs.writeFile = (filePath, js, _cb) => _cb(new Error('fake fs error'));
+          proxy.recordStop(err => {
+            fs.writeFile = writeFile;
+            if (err) {
+              cb();
+              return;
+            }
+            cb(new Error('expected error'));
+          });
+        },
+
+        // Stop recording
+        cb => {
+          proxy.recordStop(cb);
+        },
+
+        // Assert suite file exists
+        cb => {
+          fs.statSync(getSuiteFilePath(suiteName));
+          cb();
+        },
+
+        // Reset proxy services and play recorded suite
+        cb => {
+          proxy.reset();
+          cb();
+        },
+
+        cb => {
+          proxy.play(safeFilename(suiteName));
+          cb();
+        },
+
+        // Test remote url paths and their sub paths route to the same services
+        // Assert remote url paths are routed the correct responses
+        // e.g. http://localhost:4041/http://example.com/some/service
+        cb => remoteReq.get(path1).expect(200, 'first', cb),
+
+        // Assert paths are routed the correct responses
+        // e.g. http://localhost:4041/some/service
+        cb => proxyReq.get(path1).expect(200, 'first', cb)
+      ],
+      done
+    );
+  });
+});

--- a/packages/mockyeah/test/unit/safeFilename.test.js
+++ b/packages/mockyeah/test/unit/safeFilename.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const safeFilename = require('../../lib/safeFilename');
+
+describe('safeFilename', () => {
+  it('strips relative paths', () => {
+    const filename = '../../foo';
+    expect(safeFilename(filename)).to.equal('foo');
+  });
+
+  it('strips relative paths with forward slash', () => {
+    const filename = '..\\..\\foo';
+    expect(safeFilename(filename)).to.equal('foo');
+  });
+
+  it('strips absolute paths', () => {
+    const filename = '/tmp/foo';
+    expect(safeFilename(filename)).to.equal('tmp/foo');
+  });
+
+  it('strips absolute paths with forward slash', () => {
+    const filename = '\\tmp\\foo';
+    expect(safeFilename(filename)).to.equal('tmp\\foo');
+  });
+
+  it('strips double absolute paths with forward slash', () => {
+    const filename = '\\\\tmp\\foo';
+    expect(safeFilename(filename)).to.equal('tmp\\foo');
+  });
+
+  it('strips absolute paths with drive and forward slash', () => {
+    const filename = 'C:\\tmp\\foo';
+    expect(safeFilename(filename)).to.equal('tmp\\foo');
+  });
+});


### PR DESCRIPTION
Strips some bad character sequences from file names, e.g., `/`, `\\`, `C:\`, `../`, etc.