### PR TITLE
feat: optional custom dynamic suite header

### DIFF
--- a/packages/mockyeah-docs/book/Configuration.md
+++ b/packages/mockyeah-docs/book/Configuration.md
@@ -21,7 +21,11 @@
   "httpsKeyPath": undefined,
   "recordToFixtures": true,
   "recordToFixturesMode": "path",
-  "formatScript": undefined
+  "formatScript": undefined,
+  "watch": false,
+  "responseHeaders": true,
+  "groups": {},
+  "suiteHeader": "x-mockyeah-suite"
 }
 ```
 
@@ -62,6 +66,7 @@ Also supports a `.mockyeah.js` as a Node module that exports a JavaScript object
 
 - `verbose`: Boolean to toggle verbosity of mockyeah generated output.
 - `proxy`: Boolean to enable a proxy on startup.
+- `suiteHeader`: String for the header name to use to opt-in to suites dynamically.
 
 The proxy will transparently forward all non-matching requests onto their original URL.
 

--- a/packages/mockyeah/app/lib/handleDynamicSuite.js
+++ b/packages/mockyeah/app/lib/handleDynamicSuite.js
@@ -3,7 +3,9 @@ const routeMatchesRequest = require('./routeMatchesRequest');
 
 // Check for an unmounted route dynamically based on header.
 const handleDynamicSuite = (app, req, res) => {
-  const dynamicSuite = req.headers['x-mockyeah-suite'];
+  const { suiteHeader } = app.config;
+
+  const dynamicSuite = req.headers[suiteHeader];
 
   if (!dynamicSuite) return false;
 

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -23,7 +23,8 @@ const configDefaults = {
   formatScript: undefined,
   watch: false,
   responseHeaders: true,
-  groups: {}
+  groups: {},
+  suiteHeader: 'x-mockyeah-suite'
 };
 
 module.exports = (config = {}) => {

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -44,7 +44,8 @@ describe('prepareConfig', () => {
       formatScript: undefined,
       watch: false,
       responseHeaders: true,
-      groups: {}
+      groups: {},
+      suiteHeader: 'x-mockyeah-suite'
     });
   });
 
@@ -72,7 +73,8 @@ describe('prepareConfig', () => {
       formatScript: undefined,
       watch: false,
       responseHeaders: true,
-      groups: {}
+      groups: {},
+      suiteHeader: 'x-mockyeah-suite'
     });
   });
 });


### PR DESCRIPTION
Lets you configure a custom header name (default `x-mockyeah-suite`) for the dynamic suite feature.