### PR TITLE
feat: support dynamic suite as cookie

### DIFF
--- a/packages/mockyeah-docs/book/Configuration.md
+++ b/packages/mockyeah-docs/book/Configuration.md
@@ -67,6 +67,7 @@ Also supports a `.mockyeah.js` as a Node module that exports a JavaScript object
 - `verbose`: Boolean to toggle verbosity of mockyeah generated output.
 - `proxy`: Boolean to enable a proxy on startup.
 - `suiteHeader`: String for the header name to use to opt-in to suites dynamically.
+- `suiteCookie`: String for the cookie name to use to opt-in to suites dynamically.
 
 The proxy will transparently forward all non-matching requests onto their original URL.
 

--- a/packages/mockyeah/app/index.js
+++ b/packages/mockyeah/app/index.js
@@ -2,6 +2,7 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser')
 const async = require('async');
 const Logger = require('./lib/Logger');
 const RouteManager = require('./lib/RouteManager');
@@ -46,6 +47,8 @@ module.exports = function App(config) {
 
   // Provide user feedback when verbose output is enabled
   app.log('info', 'verbose output enabled', true);
+
+  app.use(cookieParser())
 
   app.use(bodyParser.json());
   app.use(bodyParser.text());

--- a/packages/mockyeah/app/lib/handleDynamicSuite.js
+++ b/packages/mockyeah/app/lib/handleDynamicSuite.js
@@ -3,9 +3,9 @@ const routeMatchesRequest = require('./routeMatchesRequest');
 
 // Check for an unmounted route dynamically based on header.
 const handleDynamicSuite = (app, req, res) => {
-  const { suiteHeader } = app.config;
+  const { suiteHeader, suiteCookie } = app.config;
 
-  const dynamicSuite = req.headers[suiteHeader];
+  const dynamicSuite = req.headers[suiteHeader] || req.cookies[suiteCookie];
 
   if (!dynamicSuite) return false;
 

--- a/packages/mockyeah/lib/prepareConfig.js
+++ b/packages/mockyeah/lib/prepareConfig.js
@@ -24,7 +24,8 @@ const configDefaults = {
   watch: false,
   responseHeaders: true,
   groups: {},
-  suiteHeader: 'x-mockyeah-suite'
+  suiteHeader: 'x-mockyeah-suite',
+  suiteCookie: 'mockyeahSuite'
 };
 
 module.exports = (config = {}) => {

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -75,6 +75,7 @@
     "body-parser": "^1.15.2",
     "chokidar": "^2.0.4",
     "clear-module": "^3.1.0",
+    "cookie-parser": "^1.4.4",
     "cors": "^2.7.1",
     "cosmiconfig": "^5.0.7",
     "create-cert-files": "^1.0.2",

--- a/packages/mockyeah/test/integration/DynamicSuiteTest.js
+++ b/packages/mockyeah/test/integration/DynamicSuiteTest.js
@@ -3,7 +3,7 @@
 const MockYeahServer = require('../../server');
 const supertest = require('supertest');
 
-describe('Dynamic Suites', function() {
+describe('Dynamic Suites', function () {
   let mockyeah;
   let request;
 
@@ -20,38 +20,77 @@ describe('Dynamic Suites', function() {
     request = supertest(mockyeah.server);
   });
 
-  it('should dynamically enable a suite per-request', function(done) {
-    request
-      .get('/say-hello')
-      .set('x-mockyeah-suite', 'some-custom-suite')
-      .expect(200, /hello there/, done);
+  describe('with header', () => {
+    it('should dynamically enable a suite per-request', function (done) {
+      request
+        .get('/say-hello')
+        .set('x-mockyeah-suite', 'some-custom-suite')
+        .expect(200, /hello there/, done);
+    });
+
+    it('should support full URL', function (done) {
+      request
+        .get('/http://localhost/say-hello')
+        .set('x-mockyeah-suite', 'some-custom-suite')
+        .expect(200, /hello absolute/, done);
+    });
+
+    it('should support aliases', function (done) {
+      request
+        .get('/http://localhost.alias.com/say-hello')
+        .set('x-mockyeah-suite', 'some-custom-suite')
+        .expect(200, /hello absolute/, done);
+    });
+
+    it('should support aliases with encoding', function (done) {
+      request
+        .get('/http~~~localhost.alias.com/say-hello')
+        .set('x-mockyeah-suite', 'some-custom-suite')
+        .expect(200, /hello absolute/, done);
+    });
+
+    it('should ignore non-existent dynamic suite', function (done) {
+      request
+        .get('/say-hello')
+        .set('x-mockyeah-suite', 'some-nonexistent-suite')
+        .expect(404, done);
+    });
   });
 
-  it('should support full URL', function(done) {
-    request
-      .get('/http://localhost/say-hello')
-      .set('x-mockyeah-suite', 'some-custom-suite')
-      .expect(200, /hello absolute/, done);
-  });
+  describe('with cookie', () => {
+    it('should dynamically enable a suite per-request', function (done) {
+      request
+        .get('/say-hello')
+        .set('Cookie', 'mockyeahSuite=some-custom-suite')
+        .expect(200, /hello there/, done);
+    });
 
-  it('should support aliases', function(done) {
-    request
-      .get('/http://localhost.alias.com/say-hello')
-      .set('x-mockyeah-suite', 'some-custom-suite')
-      .expect(200, /hello absolute/, done);
-  });
+    it('should support full URL', function (done) {
+      request
+        .get('/http://localhost/say-hello')
+        .set('Cookie', 'mockyeahSuite=some-custom-suite')
+        .expect(200, /hello absolute/, done);
+    });
 
-  it('should support aliases with encoding', function(done) {
-    request
-      .get('/http~~~localhost.alias.com/say-hello')
-      .set('x-mockyeah-suite', 'some-custom-suite')
-      .expect(200, /hello absolute/, done);
-  });
+    it('should support aliases', function (done) {
+      request
+        .get('/http://localhost.alias.com/say-hello')
+        .set('Cookie', 'mockyeahSuite=some-custom-suite')
+        .expect(200, /hello absolute/, done);
+    });
 
-  it('should ignore non-existent dynamic suite', function(done) {
-    request
-      .get('/say-hello')
-      .set('x-mockyeah-suite', 'some-nonexistent-suite')
-      .expect(404, done);
+    it('should support aliases with encoding', function (done) {
+      request
+        .get('/http~~~localhost.alias.com/say-hello')
+        .set('Cookie', 'mockyeahSuite=some-custom-suite')
+        .expect(200, /hello absolute/, done);
+    });
+
+    it('should ignore non-existent dynamic suite', function (done) {
+      request
+        .get('/say-hello')
+        .set('Cookie', 'mockyeahSuite=some-nonexistent-suite')
+        .expect(404, done);
+    });
   });
 });

--- a/packages/mockyeah/test/unit/prepareConfig.test.js
+++ b/packages/mockyeah/test/unit/prepareConfig.test.js
@@ -45,7 +45,8 @@ describe('prepareConfig', () => {
       watch: false,
       responseHeaders: true,
       groups: {},
-      suiteHeader: 'x-mockyeah-suite'
+      suiteHeader: 'x-mockyeah-suite',
+      suiteCookie: 'mockyeahSuite'
     });
   });
 
@@ -74,7 +75,8 @@ describe('prepareConfig', () => {
       watch: false,
       responseHeaders: true,
       groups: {},
-      suiteHeader: 'x-mockyeah-suite'
+      suiteHeader: 'x-mockyeah-suite',
+      suiteCookie: 'mockyeahSuite'
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,10 +739,6 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
 
-ansi-regex@*, ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -750,6 +746,10 @@ ansi-regex@^2.0.0:
 ansi-regex@^3.0.0, ansi-regex@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1877,6 +1877,13 @@ convert-source-map@^1.5.1:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-parser@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.4.tgz#e6363de4ea98c3def9697b93421c09f30cf5d188"
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -2129,7 +2136,7 @@ debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -4001,7 +4008,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -4843,10 +4850,6 @@ lodash._baseflatten@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash._baseflatten/-/lodash._baseflatten-4.2.1.tgz#54acad5e6ef53532a5b8269c0ad725470cfd9208"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4854,25 +4857,11 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -4949,10 +4938,6 @@ lodash.padstart@^4.1.0:
 lodash.rest@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/lodash.rest/-/lodash.rest-4.0.5.tgz#954ef75049262038c96d1fc98b28fdaf9f0772aa"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -7241,7 +7226,7 @@ readable-stream@~2.1.2, readable-stream@~2.1.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -8690,7 +8675,7 @@ v8flags@^2.0.11:
   dependencies:
     user-home "^1.1.1"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3, validate-npm-package-license@~3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:


### PR DESCRIPTION
Adds a similar feature to the existing `x-mockyeah-suite` HTTP header, but now also supporting as a `mockyeahSuite` cookie, whose name, like the header, can be customized in configuration, with `suiteCookie` string. The header will take precedence over the cookie if both are provided.

Also adds `cookie-parser` middleware, which could open the door for matching by cookies as a feature on top of existing header matching in the future.

Fixes #297