### PR TITLE
fix: record groups only record matches

### DIFF
--- a/packages/mockyeah/app/lib/proxyRecord.js
+++ b/packages/mockyeah/app/lib/proxyRecord.js
@@ -13,6 +13,8 @@ const proxyRecord = ({ app, req, res, reqUrl, startTime, body }) => {
   let group;
   if (groups) {
     group = groups.find(g => g.test(reqUrl));
+
+    if (!group) return;
   }
 
   const { method, body: reqBody } = req;

--- a/packages/mockyeah/test/integration/RecordGroupsTest.js
+++ b/packages/mockyeah/test/integration/RecordGroupsTest.js
@@ -12,7 +12,7 @@ const { expect } = require('chai');
 
 const ROOT = path.resolve(__dirname, '../.tmp/proxy');
 
-describe('Record Groups Test', function() {
+describe('Record Groups Test', function () {
   let proxy;
   let remote;
   let proxyReq;
@@ -21,7 +21,7 @@ describe('Record Groups Test', function() {
   before(done => {
     async.parallel(
       [
-        function(cb) {
+        function (cb) {
           // Instantiate proxy server for recording
           proxy = MockYeahServer(
             {
@@ -45,7 +45,7 @@ describe('Record Groups Test', function() {
             cb
           );
         },
-        function(cb) {
+        function (cb) {
           // Instantiate remote server
           remote = MockYeahServer(
             {
@@ -84,7 +84,7 @@ describe('Record Groups Test', function() {
     return path.resolve(ROOT, 'fixtures', groupName, suiteName, '0.txt');
   }
 
-  it('should record fixture to group subdirectory', function(done) {
+  it('should record fixture to group subdirectory', function (done) {
     this.timeout = 10000;
 
     const suiteName = 'test-some-fancy-suite-group-file';
@@ -94,11 +94,13 @@ describe('Record Groups Test', function() {
     const path1 = '/some/service/one';
     const path2 = '/some/non-subdir/service/two';
     const path3 = '/some/named-dir/service/three';
+    const path4 = '/some/other';
 
     // Mount remote service end points
     remote.get(path1, { text: 'hey there' });
     remote.get(path2, { text: 'hey non-subdir there' });
     remote.get(path3, { text: 'hey named dir there' });
+    remote.get(path4, { text: 'hey other' });
 
     // Initiate recording and playback series
     async.series(
@@ -121,6 +123,7 @@ describe('Record Groups Test', function() {
         cb => proxyReq.get(path1).expect(200, cb),
         cb => proxyReq.get(path2).expect(200, cb),
         cb => proxyReq.get(path3).expect(200, cb),
+        cb => proxyReq.get(path4).expect(200, cb),
 
         // Stop recording
         cb => {
@@ -161,6 +164,7 @@ describe('Record Groups Test', function() {
             '"fixture": "someServiceDirectoryForNamedDir/test-some-fancy-suite-group-file/0.txt"'
           );
           expect(contents).to.contain('"fixture": "test-some-fancy-suite-group-file/0.txt"');
+          expect(contents).not.to.contain('"fixture": "test-some-fancy-suite-group-file/1.txt"');
           cb();
         },
 


### PR DESCRIPTION
Looks like the record group feature added in #272 had a bug where it recorded everything rather than just the items in the group. Added a negative assertion to the unit test to cover the fix.