### PR TITLE
feat: add 'groups' alias 'group' & support string

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-record.js
+++ b/packages/mockyeah-cli/bin/mockyeah-record.js
@@ -33,6 +33,11 @@ program
     collectCommaSeparated
   )
   .option(
+    '--group [name]',
+    'alias of -g, --groups',
+    collectCommaSeparated
+  )
+  .option(
     '-o, --only [regex]',
     'only record calls to URLs matching given regex pattern (repeatable)',
     collect
@@ -96,12 +101,12 @@ global.MOCKYEAH_VERBOSE_OUTPUT = Boolean(program.verbose);
 
 boot(env => {
   const [name] = program.args;
-  const { groups, only, header, useHeaders, useLatency } = program;
+  const { groups, group, only, header, useHeaders, useLatency } = program;
 
   env.program = program;
 
   const options = {
-    groups,
+    groups: groups || group,
     only,
     headers: header,
     useHeaders,

--- a/packages/mockyeah-docs/book/CLI/CLI.md
+++ b/packages/mockyeah-docs/book/CLI/CLI.md
@@ -76,7 +76,7 @@ Usage: mockyeah-record [options]
 
   Options:
 
-    -g, --groups [name]  record with these named groups from configuration (comma-separated and/or repeatable)
+    -g, --group, --groups [name]  record with these named groups from configuration (comma-separated and/or repeatable)
     -o, --only [regex]   only record calls to URLs matching given regex pattern (repeatable)
     -h, --use-headers    record headers to response options
     -l, --use-latency    record latency to response options

--- a/packages/mockyeah/app/makeAPI/makeRecord.js
+++ b/packages/mockyeah/app/makeAPI/makeRecord.js
@@ -1,7 +1,5 @@
 const makeRecord = app => {
   const record = (name, options = {}) => {
-    let groups;
-
     app.locals.recording = true;
 
     if (!name) throw new Error('Must provide a recording name.');
@@ -23,9 +21,12 @@ const makeRecord = app => {
         return obj;
       });
 
-    // array of strings
-    if (options.groups) {
-      groups = options.groups
+    let groups = options.groups || options.group; // support alias
+
+    if (groups) {
+      groups = Array.isArray(groups) ? groups : groups.split(',').map(v => v.trim());
+
+      groups = groups
         .map(groupName => {
           // map like `{"myGroup": "/some.*/regex/"}`
           let configGroup = app.config.groups[groupName];

--- a/packages/mockyeah/test/integration/RecordGroupTest.js
+++ b/packages/mockyeah/test/integration/RecordGroupTest.js
@@ -12,7 +12,7 @@ const { expect } = require('chai');
 
 const ROOT = path.resolve(__dirname, '../.tmp/proxy');
 
-describe('Record Groups Test', function () {
+describe('Record Group Test', function () {
   let proxy;
   let remote;
   let proxyReq;
@@ -87,7 +87,7 @@ describe('Record Groups Test', function () {
   it('should record fixture to group subdirectory', function (done) {
     this.timeout = 10000;
 
-    const suiteName = 'test-some-fancy-suite-groups-file';
+    const suiteName = 'test-some-fancy-suite-group-file';
 
     // Construct remote service urls
     // e.g. http://localhost:4041/http://example.com/some/service
@@ -106,12 +106,7 @@ describe('Record Groups Test', function () {
         // Initiate recording
         cb => {
           proxy.record(suiteName, {
-            groups: [
-              'someService',
-              'someNonSubdirGroup',
-              'someServiceNamedDir',
-              'unknownGroupSpecified'
-            ]
+            group: 'someService,someNonSubdirGroup , someServiceNamedDir,unknownGroupSpecified'
           });
           cb();
         },
@@ -155,12 +150,12 @@ describe('Record Groups Test', function () {
         cb => {
           const contents = fs.readFileSync(getSuiteFilePath(suiteName), 'utf8');
           expect(contents).to.contain(
-            '"fixture": "someService/test-some-fancy-suite-groups-file/0.txt"'
+            '"fixture": "someService/test-some-fancy-suite-group-file/0.txt"'
           );
           expect(contents).to.contain(
-            '"fixture": "someServiceDirectoryForNamedDir/test-some-fancy-suite-groups-file/0.txt"'
+            '"fixture": "someServiceDirectoryForNamedDir/test-some-fancy-suite-group-file/0.txt"'
           );
-          expect(contents).to.contain('"fixture": "test-some-fancy-suite-groups-file/0.txt"');
+          expect(contents).to.contain('"fixture": "test-some-fancy-suite-group-file/0.txt"');
           cb();
         },
 


### PR DESCRIPTION
Adds an alias `group` for `groups` since I found the pluralization sometimes confusing. Support both on the CLI as `--group` as well as programmatically with `.record({ group: { ... } })`.

Also adds support for passing `group` as a string, which can be a single group, or a comma-separated list of groups.