### PR TITLE
chore: no longer publish archive docs

### DIFF
--- a/packages/mockyeah-docs/book/SUMMARY.md
+++ b/packages/mockyeah-docs/book/SUMMARY.md
@@ -41,4 +41,3 @@
 - [CLI](CLI/CLI.md)
 - [Recipes & Examples](https://github.com/mockyeah/mockyeah/tree/master/examples)
 - [Contributing](Contributing.md)
-- [v0.x docs](https://mockyeah.js.org/archive/0.16/index.html)

--- a/packages/mockyeah-docs/package.json
+++ b/packages/mockyeah-docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "gitbook serve",
     "build": "gitbook build",
-    "docs:publish": "yarn build && git checkout f1d15fb && mkdir -p _book/archive/0.16 && gitbook build . _book/archive/0.16 && cp CNAME _book/CNAME && gh-pages -d _book && git checkout -"
+    "docs:publish": "yarn build && cp CNAME _book/CNAME && gh-pages -d _book"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",
   "author": "Ryan Ricard",


### PR DESCRIPTION
Deciding to no longer publish archive docs since it makes the publish process a bit complicated. Old docs should be available in the git history for those that need them.