### PR TITLE
feat: adds CLI start command, with --watch flag

### DIFF
--- a/packages/mockyeah-cli/bin/index.js
+++ b/packages/mockyeah-cli/bin/index.js
@@ -21,5 +21,6 @@ boot(() => {
     .command('play [name]', 'play suite')
     .command('playAll', 'play all suites')
     .command('record [name]', 'record suite')
+    .command('start', 'start server')
     .parse(process.argv);
 });

--- a/packages/mockyeah-cli/bin/mockyeah-start.js
+++ b/packages/mockyeah-cli/bin/mockyeah-start.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/* eslint-disable no-console, no-sync */
+
+/**
+ * `mockyeah start` just starts the server.
+ */
+
+const program = require('commander');
+const boot = require('../lib/boot');
+
+program
+  .option('-w, --watch', 'enable watch mode')
+  .parse(process.argv);
+
+boot(env => {
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  const mockyeah = require(env.modulePath);
+
+  if (program.watch) {
+    mockyeah.watch();
+  }
+});

--- a/packages/mockyeah-docs/book/CLI/CLI.md
+++ b/packages/mockyeah-docs/book/CLI/CLI.md
@@ -59,6 +59,7 @@ Usage: mockyeah [options] [command]
     play [name]    play suite
     playAll        play all suites
     record [name]  record suite
+    start          start server
     help [cmd]     display help for [cmd]
 
   Options:

--- a/packages/mockyeah/app/makeAPI/makeUnwatch.js
+++ b/packages/mockyeah/app/makeAPI/makeUnwatch.js
@@ -5,6 +5,8 @@ const makeUnwatch = app => {
     if (!watcher) return;
 
     watcher.close();
+
+    app.log('watch', 'stopped watching');
   };
 
   return unwatch;

--- a/packages/mockyeah/app/makeAPI/makeWatch.js
+++ b/packages/mockyeah/app/makeAPI/makeWatch.js
@@ -40,6 +40,7 @@ const makeWatch = app => {
 
   const watch = () => {
     const watcher = chokidar.watch([suitesDir, fixturesDir]).on('all', debounced);
+    app.log('watch', 'started watching');
     app.locals.watcher = watcher;
   };
 


### PR DESCRIPTION
Adds a `mockyeah start` command to start up the server without playing any suites.

Also supports a `--watch` or `-w` flag to start up in watch mode, so you can ad-hoc watch even when `watch: true` is not the default in configuration.

Also adds some logging for start and stop watching.

Fixes #150.
