### PR TITLE
docs: import mockyeah/server

### DIFF
--- a/packages/mockyeah-docs/book/API/Server.md
+++ b/packages/mockyeah-docs/book/API/Server.md
@@ -10,19 +10,13 @@ Use it to programmatically construct your own instance of mockyeah, perhaps with
 First import it:
 
 ```js
-import { Server } from "mockyeah";
+import Server from "mockyeah/server";
 ```
 
 or:
 
 ```js
-const { Server } = require("mockyeah");
-```
-
-or:
-
-```js
-const Server = require("mockyeah").Server;
+const Server = require("mockyeah/server");
 ```
 
 Then use it:


### PR DESCRIPTION
For programmatic server use, we'll encourage importing from `mockyeah/server` directly so that we default mockyeah instance isn't started automatically, as with imports of `mockyeah` at the root level.