### PR TITLE
feat: log request match errors (verbosely)

### DIFF
--- a/packages/mockyeah/app/lib/RouteManager.js
+++ b/packages/mockyeah/app/lib/RouteManager.js
@@ -10,14 +10,14 @@ module.exports = function RouteManager(app) {
   const routeResolver = new RouteResolver(app);
 
   return {
-    register: function register(method, _path, response) {
+    register: function register(method, _path, response, options) {
       app.log(['serve', 'mount', method], _path.path || _path.url || _path);
-      return routeResolver.register(method, _path, response);
+      return routeResolver.register(method, _path, response, options);
     },
 
-    all: function all(_path, response) {
+    all: function all(_path, response, options) {
       const method = _path.method ? _path.method.toLowerCase() : 'all';
-      return this.register(method, _path, response);
+      return this.register(method, _path, response, options);
     },
 
     get: function get(_path, response) {

--- a/packages/mockyeah/app/lib/RouteResolver.js
+++ b/packages/mockyeah/app/lib/RouteResolver.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const Expectation = require('./Expectation');
 const { compileRoute } = require('./helpers');
+const logMatchError = require('./logMatchError');
 const routeMatchesRequest = require('./routeMatchesRequest');
 const handleDynamicSuite = require('./handleDynamicSuite');
 
@@ -31,7 +32,8 @@ function listen() {
 
     const route = routes.find(r =>
       routeMatchesRequest(r, req, {
-        aliases
+        aliases,
+        log: logMatchError.bind(null, app)
       })
     );
 
@@ -84,15 +86,15 @@ function RouteResolver(app) {
   listen.call(this);
 }
 
-RouteResolver.prototype.register = function register(method, _path, response) {
+RouteResolver.prototype.register = function register(method, _path, response, options) {
   const match = _.isPlainObject(_path)
     ? Object.assign({ method }, _path)
     : {
-        method,
-        path: _path
-      };
+      method,
+      path: _path
+    };
 
-  const route = compileRoute(match, response);
+  const route = compileRoute(match, response, options);
 
   const expectation = new Expectation(route);
   route.expectation = expectation;

--- a/packages/mockyeah/app/lib/handleDynamicSuite.js
+++ b/packages/mockyeah/app/lib/handleDynamicSuite.js
@@ -1,4 +1,5 @@
 const { compileRoute, requireSuite } = require('./helpers');
+const logMatchError = require('./logMatchError');
 const routeMatchesRequest = require('./routeMatchesRequest');
 
 // Check for an unmounted route dynamically based on header.
@@ -23,7 +24,8 @@ const handleDynamicSuite = (app, req, res) => {
     compiledRoute = compileRoute(r[0], r[1]);
 
     return routeMatchesRequest(compiledRoute, req, {
-      aliases
+      aliases,
+      log: logMatchError.bind(null, app)
     });
   });
 

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -148,7 +148,7 @@ const handlePathTypes = (_path, _query) => {
   throw new Error(`Unsupported path type ${typeof _path}: ${_path}`);
 };
 
-const compileRoute = (match, response) => {
+const compileRoute = (match, response, options = {}) => {
   const route = {
     method: match.method || 'get',
     response
@@ -176,6 +176,9 @@ const compileRoute = (match, response) => {
       }
     );
   }
+
+  route.suiteName = options.suiteName;
+  route.suiteIndex = options.suiteIndex;
 
   return route;
 };

--- a/packages/mockyeah/app/lib/logMatchError.js
+++ b/packages/mockyeah/app/lib/logMatchError.js
@@ -1,0 +1,13 @@
+const logMatchError = (app, { match, route }) => {
+  const { suiteName, suiteIndex } = route;
+  const suiteLabel = suiteName && `${suiteName}[${suiteIndex || 0}]`;
+  const safeSuiteLabel = suiteLabel ? `${suiteLabel} ` : '';
+  if (match.errors) {
+    match.errors.forEach(error => {
+      const keyPath = error.keyPath.join('.');
+      app.log(['match', 'error'], `${safeSuiteLabel}"${keyPath}": ${error.message}`, true);
+    });
+  }
+}
+
+module.exports = logMatchError;

--- a/packages/mockyeah/app/lib/routeMatchesRequest.js
+++ b/packages/mockyeah/app/lib/routeMatchesRequest.js
@@ -52,7 +52,7 @@ const routeMatchesRequestAliases = (normalizedRoute, normalizedReq, url, options
 };
 
 // TODO: Refactor to return match object, not just result boolean.
-const routeMatchesRequest = (route, req, options) => {
+const routeMatchesRequest = (route, req, options = {}) => {
   // TODO: Later add features to match other things, like cookies, or with other types, etc.
 
   const normalizedRoute = {
@@ -82,6 +82,8 @@ const routeMatchesRequest = (route, req, options) => {
   }
 
   const match = matches(normalizedReq, normalizedRoute);
+
+  if (options.log) options.log({ match, route });
 
   if (match.result) return true;
 

--- a/packages/mockyeah/app/makeAPI/makePlay.js
+++ b/packages/mockyeah/app/makeAPI/makePlay.js
@@ -10,7 +10,10 @@ const makePlay = app => {
 
     app.log(['serve', 'play'], name);
 
-    suite.map(c => app.routeManager.all(...c));
+    suite.map((c, i) => app.routeManager.all(...c, {
+      suiteName: name,
+      suiteIndex: i
+    }));
   };
 
   return play;


### PR DESCRIPTION
Adds verbose logs for any match errors for incoming requests. Includes suite name, index of mock within suite, and the error message including key path.

<img width="840" alt="Screen Shot 2019-05-01 at 6 17 10 PM" src="https://user-images.githubusercontent.com/615381/57049626-819f8c80-6c3e-11e9-8a08-7ed3d444b1b0.png">
