### PR TITLE
fix: no error on close when not running

### DIFF
--- a/packages/mockyeah/server/index.js
+++ b/packages/mockyeah/server/index.js
@@ -145,13 +145,15 @@ module.exports = function Server(config, onStart) {
         cb =>
           server.close(err => {
             app.log(['serve', 'exit'], 'Goodbye.');
-            cb(err);
+            if (err && err.code === 'ERR_SERVER_NOT_RUNNING') cb()
+            else cb(err);
           }),
         adminServer &&
         (cb =>
           adminServer.close(err => {
             app.log(['admin', 'serve', 'exit'], 'Goodbye.');
-            cb(err);
+            if (err && err.code === 'ERR_SERVER_NOT_RUNNING') cb()
+            else cb(err);
           }))
       ].filter(Boolean);
 


### PR DESCRIPTION
Seeing errors in tests when calling `.close()` in `after()` but the server has somehow already stopped running. Adding a check to suppress the `ERR_SERVER_NOT_RUNNING` error.