### PR TITLE
fix: detect server not running errors in Node 6

### DIFF
--- a/packages/mockyeah/server/index.js
+++ b/packages/mockyeah/server/index.js
@@ -10,6 +10,9 @@ const App = require('../app');
 const prepareConfig = require('../lib/prepareConfig');
 const AdminServer = require('./admin');
 
+const isErrorServerNotRunning = error =>
+  error && (error.code === 'ERR_SERVER_NOT_RUNNING' || error.message.includes('Not running'));
+
 /**
  * Server module
  * @param  {Object} config Application configuration.
@@ -145,14 +148,14 @@ module.exports = function Server(config, onStart) {
         cb =>
           server.close(err => {
             app.log(['serve', 'exit'], 'Goodbye.');
-            if (err && err.code === 'ERR_SERVER_NOT_RUNNING') cb();
+            if (isErrorServerNotRunning(err)) cb();
             else cb(err);
           }),
         adminServer &&
           (cb =>
             adminServer.close(err => {
               app.log(['admin', 'serve', 'exit'], 'Goodbye.');
-              if (err && err.code === 'ERR_SERVER_NOT_RUNNING') cb();
+              if (isErrorServerNotRunning(err)) cb();
               else cb(err);
             }))
       ].filter(Boolean);


### PR DESCRIPTION
To support handling the "server not running" error when calling `close` (#345) for Node less than 8, where `error.code` does not exist, we need to also check the error message.