### PR TITLE
feat: watch callback and promise

### DIFF
--- a/packages/mockyeah/app/makeAPI/makeWatch.js
+++ b/packages/mockyeah/app/makeAPI/makeWatch.js
@@ -38,11 +38,23 @@ const makeWatch = app => {
     restart(app);
   }, 500);
 
-  const watch = () => {
-    const watcher = chokidar.watch([suitesDir, fixturesDir]).on('all', debounced);
-    app.log('watch', 'started watching');
-    app.locals.watcher = watcher;
-  };
+  const watch = callback =>
+    new Promise((resolve, reject) => {
+      const watcher = chokidar.watch([suitesDir, fixturesDir]);
+      watcher.on('ready', err => {
+        if (callback) callback(err);
+        if (err) reject(err);
+        else resolve();
+      });
+      watcher.on('error', err => {
+        app.log(['watch', 'error'], err && err.message);
+        if (callback) callback(err);
+        reject(err);
+      });
+      watcher.on('all', debounced);
+      app.log('watch', 'started watching');
+      app.locals.watcher = watcher;
+    });
 
   return watch;
 };

--- a/packages/mockyeah/test/integration/WatchTest.js
+++ b/packages/mockyeah/test/integration/WatchTest.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const fs = require('fs-extra');
+const chokidar = require('chokidar');
+const async = require('async');
 require('../TestHelper');
 const MockYeahServer = require('../../server');
 const supertest = require('supertest');
@@ -9,6 +11,8 @@ const watchedSuiteDir = `${__dirname}/../mockyeah/test-some-custom-watcher-suite
 const watchedSuiteFile = `${watchedSuiteDir}/index.js`;
 
 const root = `${__dirname}/../`;
+
+const chokidarWatch = chokidar.watch;
 
 describe('Watcher Test', () => {
   beforeEach(() => {
@@ -19,6 +23,7 @@ describe('Watcher Test', () => {
   afterEach(() => {
     // eslint-disable-next-line no-sync
     fs.removeSync(watchedSuiteDir);
+    chokidar.watch = chokidarWatch;
   });
 
   it('should watch programmatically with callback', function(done) {
@@ -104,6 +109,39 @@ describe('Watcher Test', () => {
         }, 1000);
       })
       .catch(done);
+  });
+
+  it('should watch programmatically with error', function(done) {
+    this.timeout(10000);
+
+    chokidar.watch = () => ({
+      on(event, callback) {
+        if (event === 'error') callback(new Error('fake error'));
+      }
+    });
+
+    const mockyeah = new MockYeahServer({ port: 0, adminPort: 0, root, watch: false });
+
+    const cbs = [];
+    async.times(2, (__, cb) => cbs.push(cb), done);
+
+    mockyeah
+      .watch(err => {
+        if (err && err.message === 'fake error') {
+          if (err.message === 'fake error') cbs[0]();
+          else cbs[0](new Error('expected fake error'));
+          return;
+        }
+
+        cbs[0](new Error('expected error'));
+      })
+      .then(() => {
+        cbs[1](new Error('expected error'));
+      })
+      .catch(err => {
+        if (err.message === 'fake error') cbs[1]();
+        else cbs[1](new Error('expected fake error'));
+      });
   });
 
   it('should watch based on config', function(done) {


### PR DESCRIPTION
Adds an optional callback to `.watch()` and returns a Promise. Uses `chokidar`'s `ready` event.