### PR TITLE
test: after all use close promises

### DIFF
--- a/packages/mockyeah/test/TestHelper.js
+++ b/packages/mockyeah/test/TestHelper.js
@@ -21,10 +21,7 @@ const configHttps = Object.assign({}, mockyeah.config, {
 });
 const mockyeahHttps = new Server(configHttps);
 
-after(() => {
-  mockyeah.close();
-  mockyeahHttps.close();
-});
+after(() => Promise.all([mockyeah.close(), mockyeahHttps.close()]));
 
 afterEach(() => {
   mockyeah.reset();


### PR DESCRIPTION
Use the new `close` promise support to make sure tests `after` waits for servers to close.