### PR TITLE
feat: x-mockyeah-missed header

### DIFF
--- a/packages/mockyeah/app/lib/RouteResolver.js
+++ b/packages/mockyeah/app/lib/RouteResolver.js
@@ -38,7 +38,10 @@ function listen() {
     );
 
     if (!route) {
+      res.set('x-mockyeah-missed', 'true');
+
       next();
+
       return;
     }
 

--- a/packages/mockyeah/test/integration/MissedTest.js
+++ b/packages/mockyeah/test/integration/MissedTest.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const TestHelper = require('../TestHelper');
+
+const { request } = TestHelper;
+
+describe('Missed', function() {
+  it('should miss unmounted mock', () =>
+    request
+      .get('/nope')
+      .expect('x-mockyeah-missed', 'true')
+      .expect(404));
+});

--- a/packages/mockyeah/test/integration/RouteProxyTest.js
+++ b/packages/mockyeah/test/integration/RouteProxyTest.js
@@ -61,6 +61,24 @@ describe('Route proxy', () => {
     mockyeah.reset();
   });
 
+  it('should indicate missed header', done => {
+    async.series(
+      [
+        cb =>
+          supertest(proxiedApp)
+            .get('/foo')
+            .expect(200, cb),
+        cb =>
+          request
+            .get(`/http://localhost:${proxiedPort}/nope?ok=yes`)
+            .expect('x-mockyeah-missed', 'true')
+            .expect(404)
+            .end(cb)
+      ],
+      done
+    );
+  });
+
   it('should support registering full URLs manually', done => {
     mockyeah.get(`/http://localhost:${proxiedPort}/foo?ok=yes`, { text: 'bar', status: 500 });
 


### PR DESCRIPTION
Adds a `x-mockyeah-missed: true` header when no mock matches, whether or not we are proxying (so it may co-occur with `x-mockyeah-proxied: true` header.