### PR TITLE
feat: close() unwatches, remove shutdown()

### DIFF
--- a/packages/mockyeah-docs/book/API/close.md
+++ b/packages/mockyeah-docs/book/API/close.md
@@ -5,8 +5,10 @@
 `callback` (`Function`; optional) To be exceuted when closing completes.
 Passed an error as first argument if the closing fails. Also returns a promise.
 
-Stops mockyeah Express server. Useful when running mockyeah with a file watcher.
-mockyeah will attempt to start a new instance of Express with each iteration of
-test execution. After all tests run, `mockyeah.close()` should be called to
+Stops mockyeah Express server.
+
+Also implicitly calls [`unwatch()`](./unwatch.md) to stop the file watching.
+
+After all tests run, `mockyeah.close()` should be called to
 shutdown mockyeah's Express server. Failing to do so will result in `EADDRINUSE`
 exceptions. This is due to mockyeah attempting to start a server on an occupied port.

--- a/packages/mockyeah-docs/book/API/shutdown.md
+++ b/packages/mockyeah-docs/book/API/shutdown.md
@@ -1,7 +1,0 @@
-# `shutdown()`
-
-`mockyeah.shutdown(callback)`
-
-Combines [`shutdown()`](./shutdown.md) and [`unwatch()`](./unwatch.md).
-Optional callback to be exceuted when closing completes.
-Passed an error as first argument if the closing fails. Also returns a promise.

--- a/packages/mockyeah/server/index.js
+++ b/packages/mockyeah/server/index.js
@@ -134,6 +134,8 @@ module.exports = function Server(config, onStart) {
 
   // Expose ability to stop server via API
   const close = function close(done) {
+    app.unwatch();
+
     return new Promise((resolve, reject) => {
       const doneAndResolve = err => {
         if (done) done(err);
@@ -164,11 +166,6 @@ module.exports = function Server(config, onStart) {
     });
   };
 
-  const shutdown = done => {
-    app.unwatch();
-    return close(done);
-  };
-
   const { proxy, reset, play, playAll, record, recordStop, watch, unwatch } = app;
 
   // Construct and return mockyeah API
@@ -183,7 +180,6 @@ module.exports = function Server(config, onStart) {
     recordStop,
     reset,
     server,
-    shutdown,
     start,
     startedPromise,
     unwatch,

--- a/packages/mockyeah/test/integration/WatchTest.js
+++ b/packages/mockyeah/test/integration/WatchTest.js
@@ -61,7 +61,7 @@ describe('Watcher Test', () => {
           supertest(mockyeah.server)
             .get('/watched')
             .expect(200, 'watched!', err => {
-              mockyeah.shutdown();
+              mockyeah.close();
               return err ? done(err) : done();
             });
         }, 1000);
@@ -102,7 +102,7 @@ describe('Watcher Test', () => {
             supertest(mockyeah.server)
               .get('/watched')
               .expect(200, 'watched!', err => {
-                mockyeah.shutdown();
+                mockyeah.close();
                 return err ? done(err) : done();
               });
           }, 1000);
@@ -174,7 +174,7 @@ describe('Watcher Test', () => {
         supertest(mockyeah.server)
           .get('/watched')
           .expect(200, 'watched!', err => {
-            mockyeah.shutdown();
+            mockyeah.close();
             return err ? done(err) : done();
           });
       }, 1000);
@@ -211,7 +211,7 @@ describe('Watcher Test', () => {
         supertest(mockyeah.server)
           .get('/watched')
           .expect(404, err => {
-            mockyeah.shutdown();
+            mockyeah.close();
             return err ? done(err) : done();
           });
       }, 1000);


### PR DESCRIPTION
We don't really need a separate `.shutdown()` command to `.close()` and `.unwatch()`. I'd added this not too long ago but am deciding to remove it for simplicity. Technically a breaking change, but probably few using it yet since it's not documented, so not a huge deal.