### PR TITLE
test: use close() async properly

### DIFF
--- a/packages/mockyeah/test/integration/RecordAndPlayAdminServerTest.js
+++ b/packages/mockyeah/test/integration/RecordAndPlayAdminServerTest.js
@@ -61,10 +61,7 @@ describe('Record and Playback Admin Server', function() {
     rimraf.sync(PROXY_SUITES_DIR);
   });
 
-  after(() => {
-    proxy.close();
-    remote.close();
-  });
+  after(() => Promise.all([proxy.close(), remote.close()]));
 
   function getSuiteFilePath(suiteName) {
     return path.resolve(PROXY_SUITES_DIR, suiteName, 'index.js');

--- a/packages/mockyeah/test/integration/RecordAndPlayTest.js
+++ b/packages/mockyeah/test/integration/RecordAndPlayTest.js
@@ -59,10 +59,7 @@ describe('Record and Playback', function() {
     rimraf.sync(PROXY_SUITES_DIR);
   });
 
-  after(() => {
-    proxy.close();
-    remote.close();
-  });
+  after(() => Promise.all([proxy.close(), remote.close()]));
 
   function getSuiteFilePath(suiteName) {
     return path.resolve(PROXY_SUITES_DIR, suiteName, 'index.js');

--- a/packages/mockyeah/test/integration/RecordBadFilenameTest.js
+++ b/packages/mockyeah/test/integration/RecordBadFilenameTest.js
@@ -59,10 +59,7 @@ describe('Record and Playback Bad Filename', function() {
     rimraf.sync(PROXY_SUITES_DIR);
   });
 
-  after(() => {
-    proxy.close();
-    remote.close();
-  });
+  after(() => Promise.all([proxy.close(), remote.close()]));
 
   function getSuiteFilePath(suiteName) {
     return path.resolve(PROXY_SUITES_DIR, safeFilename(suiteName), 'index.js');

--- a/packages/mockyeah/test/integration/RecordFormatScriptFileTest.js
+++ b/packages/mockyeah/test/integration/RecordFormatScriptFileTest.js
@@ -60,10 +60,7 @@ describe('Record Format Script File Test', function() {
     rimraf.sync(PROXY_SUITES_DIR);
   });
 
-  after(() => {
-    proxy.close();
-    remote.close();
-  });
+  after(() => Promise.all([proxy.close(), remote.close()]));
 
   function getSuiteFilePath(suiteName) {
     return path.resolve(PROXY_SUITES_DIR, suiteName, 'index.js');

--- a/packages/mockyeah/test/integration/RecordFormatScriptFunctionTest.js
+++ b/packages/mockyeah/test/integration/RecordFormatScriptFunctionTest.js
@@ -61,10 +61,7 @@ describe('Record Format Script Function Test', function() {
     rimraf.sync(PROXY_SUITES_DIR);
   });
 
-  after(() => {
-    proxy.close();
-    remote.close();
-  });
+  after(() => Promise.all([proxy.close(), remote.close()]));
 
   function getSuiteFilePath(suiteName) {
     return path.resolve(PROXY_SUITES_DIR, suiteName, 'index.js');

--- a/packages/mockyeah/test/integration/RecordGroupTest.js
+++ b/packages/mockyeah/test/integration/RecordGroupTest.js
@@ -71,10 +71,7 @@ describe('Record Group Test', function() {
     rimraf.sync(ROOT);
   });
 
-  after(() => {
-    proxy.close();
-    remote.close();
-  });
+  after(() => Promise.all([proxy.close(), remote.close()]));
 
   function getSuiteFilePath(suiteName) {
     return path.resolve(ROOT, 'mockyeah', suiteName, 'index.js');

--- a/packages/mockyeah/test/integration/RecordGroupsTest.js
+++ b/packages/mockyeah/test/integration/RecordGroupsTest.js
@@ -71,10 +71,7 @@ describe('Record Groups Test', function() {
     rimraf.sync(ROOT);
   });
 
-  after(() => {
-    proxy.close();
-    remote.close();
-  });
+  after(() => Promise.all([proxy.close(), remote.close()]));
 
   function getSuiteFilePath(suiteName) {
     return path.resolve(ROOT, 'mockyeah', suiteName, 'index.js');

--- a/packages/mockyeah/test/integration/RouteResetTest.js
+++ b/packages/mockyeah/test/integration/RouteResetTest.js
@@ -18,6 +18,7 @@ describe('Route reset', () => {
   });
 
   after(() => mockyeah.close());
+
   afterEach(() => mockyeah.reset());
 
   it('should reset all routes when no paths are passed', done => {

--- a/packages/mockyeah/test/integration/WatchTest.js
+++ b/packages/mockyeah/test/integration/WatchTest.js
@@ -61,8 +61,7 @@ describe('Watcher Test', () => {
           supertest(mockyeah.server)
             .get('/watched')
             .expect(200, 'watched!', err => {
-              mockyeah.shutdown();
-              return err ? done(err) : done();
+              mockyeah.close(shutErr => done(err || shutErr));
             });
         }, 1000);
       }, 1000);
@@ -102,8 +101,7 @@ describe('Watcher Test', () => {
             supertest(mockyeah.server)
               .get('/watched')
               .expect(200, 'watched!', err => {
-                mockyeah.shutdown();
-                return err ? done(err) : done();
+                mockyeah.close(shutErr => done(err || shutErr));
               });
           }, 1000);
         }, 1000);
@@ -174,8 +172,7 @@ describe('Watcher Test', () => {
         supertest(mockyeah.server)
           .get('/watched')
           .expect(200, 'watched!', err => {
-            mockyeah.shutdown();
-            return err ? done(err) : done();
+            mockyeah.close(shutErr => done(err || shutErr));
           });
       }, 1000);
     }, 1000);
@@ -211,8 +208,7 @@ describe('Watcher Test', () => {
         supertest(mockyeah.server)
           .get('/watched')
           .expect(404, err => {
-            mockyeah.shutdown();
-            return err ? done(err) : done();
+            mockyeah.close(shutErr => done(err || shutErr));
           });
       }, 1000);
     }, 1000);


### PR DESCRIPTION
In tests, we should always use the promise or callback support of `.close()` to be sure async handles are captured.