### PR TITLE
fix(cli): remove extra program parse

### DIFF
--- a/packages/mockyeah-cli/bin/index.js
+++ b/packages/mockyeah-cli/bin/index.js
@@ -12,8 +12,6 @@ const program = require('commander');
 const boot = require('../lib/boot');
 const version = require('../version');
 
-program.parse(process.argv);
-
 boot(() => {
   program
     .version(version)


### PR DESCRIPTION
This inadvertent double call to `program.parse` was breaking `-V, --version`, and probably causing other problems.

Fixes #323.
