### PR TITLE
refactor(cli): move bin/index to bin/mockyeah

### DIFF
--- a/packages/mockyeah-cli/bin/index.js
+++ b/packages/mockyeah-cli/bin/index.js
@@ -2,25 +2,4 @@
 
 'use strict';
 
-/**
- * mockyeah cli api "table of contents".
- * Root `mockyeah` command does not invoke behavior other than
- * providing user with a catalog of available actions.
- */
-
-const program = require('commander');
-const boot = require('../lib/boot');
-const version = require('../version');
-
-program.parse(process.argv);
-
-boot(() => {
-  program
-    .version(version)
-    .command('ls', 'list suites')
-    .command('play [suiteNames]', 'play suite(s)')
-    .command('playAll', 'play all suites')
-    .command('record [suiteName]', 'record suite')
-    .command('start', 'start server')
-    .parse(process.argv);
-});
+module.exports = require('./mockyeah');

--- a/packages/mockyeah-cli/bin/index.js
+++ b/packages/mockyeah-cli/bin/index.js
@@ -2,4 +2,4 @@
 
 'use strict';
 
-module.exports = require('./mockyeah');
+require('./mockyeah');

--- a/packages/mockyeah-cli/bin/mockyeah.js
+++ b/packages/mockyeah-cli/bin/mockyeah.js
@@ -12,6 +12,7 @@ const version = require('../version');
 
 boot(() => {
   program
+    .name('mockyeah')
     .version(version)
     .command('ls', 'list suites')
     .command('play [suiteNames]', 'play suite(s)')

--- a/packages/mockyeah-cli/bin/mockyeah.js
+++ b/packages/mockyeah-cli/bin/mockyeah.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * mockyeah cli api "table of contents".
+ * Root `mockyeah` command does not invoke behavior other than
+ * providing user with a catalog of available actions.
+ */
+
+const program = require('commander');
+const boot = require('../lib/boot');
+const version = require('../version');
+
+boot(() => {
+  program
+    .version(version)
+    .command('ls', 'list suites')
+    .command('play [suiteNames]', 'play suite(s)')
+    .command('playAll', 'play all suites')
+    .command('record [suiteName]', 'record suite')
+    .command('start', 'start server')
+    .parse(process.argv);
+});


### PR DESCRIPTION
This allows us to use `node bin/mockyeah start` in development, whereas before it would complain that `index-start` does not exist, and fail. Moves logic from `bin/index.js` to `bin/mockyeah.js`, which `bin/index.js` now `require`s. Also adds ` .name('mockyeah')` to the commander setup for console messages.
