### PR TITLE
feat(cli): aliases for list and play-all

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah-list.js
+++ b/packages/mockyeah-cli/bin/mockyeah-list.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console, no-sync */
 
 /**
- * `mockyeah ls` lists service recordings.
+ * `mockyeah list` lists suites.
  */
 
 const fs = require('fs');

--- a/packages/mockyeah-cli/bin/mockyeah.js
+++ b/packages/mockyeah-cli/bin/mockyeah.js
@@ -14,9 +14,11 @@ boot(() => {
   program
     .name('mockyeah')
     .version(version)
-    .command('ls', 'list suites')
+    .command('list', 'list suites')
+    .alias('ls')
     .command('play [suiteNames]', 'play suite(s)')
     .command('playAll', 'play all suites')
+    .alias('play-all')
     .command('record [suiteName]', 'record suite')
     .command('start', 'start server')
     .parse(process.argv);


### PR DESCRIPTION
For CLI, renames `ls` to `list` for better usability, but adds an alias `ls` to it to retain that option. Also adds an alias `play-all` to `playAll` in case people try to use the kebab-case form usually seen in subcommand apps like this.