### PR TITLE
docs(cli): update github link in README

### DIFF
--- a/packages/mockyeah-cli/README.md
+++ b/packages/mockyeah-cli/README.md
@@ -1,6 +1,6 @@
 # mockyeah-cli
 
-Command line utility for [mockyeah](https://github.com/ryanricard/mockyeah),
+Command line utility for [mockyeah](https://github.com/mockyeah/mockyeah),
 a powerful service mocking, recording, and playback utility.
 
 <img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/logo/mockyeah-600.png" height="200" />


### PR DESCRIPTION
We had an old GitHub link in the README for the CLI.