### PR TITLE
docs: fix images in sub-repo readmes again

### DIFF
--- a/packages/mockyeah-cli/README.md
+++ b/packages/mockyeah-cli/README.md
@@ -3,7 +3,7 @@
 Command line utility for [mockyeah](https://github.com/mockyeah/mockyeah),
 a powerful service mocking, recording, and playback utility.
 
-<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/logo/mockyeah-600.png" height="200" />
+<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/images/logo/mockyeah-600.png" height="200" />
 
 [![npm](https://img.shields.io/npm/v/mockyeah-cli.svg)](https://www.npmjs.com/package/mockyeah-cli)
 

--- a/packages/mockyeah-test-jest/README.md
+++ b/packages/mockyeah-test-jest/README.md
@@ -3,7 +3,7 @@
 [Jest](https://jestjs.io) unit test setup for [mockyeah](https://github.com/mockyeah/mockyeah),
 a powerful service mocking, recording, and playback utility.
 
-<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/logo/mockyeah-600.png" height="200" />
+<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/images/logo/mockyeah-600.png" height="200" />
 
 [![npm](https://img.shields.io/npm/v/mockyeah-test-jest.svg)](https://www.npmjs.com/package/mockyeah-test-jest)
 

--- a/packages/mockyeah-test-mocha/README.md
+++ b/packages/mockyeah-test-mocha/README.md
@@ -3,7 +3,7 @@
 [Mocha](https://mochajs.org) unit test setup for [mockyeah](https://github.com/mockyeah/mockyeah),
 a powerful service mocking, recording, and playback utility.
 
-<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/logo/mockyeah-600.png" height="200" />
+<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/images/logo/mockyeah-600.png" height="200" />
 
 [![npm](https://img.shields.io/npm/v/mockyeah-test-mocha.svg)](https://www.npmjs.com/package/mockyeah-test-mocha)
 

--- a/packages/mockyeah/README.md
+++ b/packages/mockyeah/README.md
@@ -2,7 +2,7 @@
 
 **A powerful service mocking, recording, and playback utility.**
 
-<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/logo/mockyeah-600.png" height="200" />
+<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/book/images/logo/mockyeah-600.png" height="200" />
 
 [![npm](https://img.shields.io/npm/v/mockyeah.svg)](https://www.npmjs.com/package/mockyeah)
 [![Travis](https://img.shields.io/travis/mockyeah/mockyeah.svg)](https://travis-ci.org/mockyeah/mockyeah)


### PR DESCRIPTION
Looks like the URL for the logo images in the sub-repo READMEs was wrong.