### PR TITLE
fix: match-deep errors period-separated

### DIFF
--- a/packages/match-deep/src/index.ts
+++ b/packages/match-deep/src/index.ts
@@ -24,7 +24,8 @@ interface MatchError {
 
 const DEFAULT_MATCH_OPTIONS: MatchOptions = {};
 
-const makeMatcher = ({ shortCircuit, skipKeys } = DEFAULT_MATCH_OPTIONS) => {
+const makeMatcher = (options = DEFAULT_MATCH_OPTIONS) => {
+  const { shortCircuit, skipKeys } = options;
   const errors: MatchError[] = [];
 
   const internalMatcher = (value: any, source: any, keyPath: string[]) => {
@@ -96,7 +97,7 @@ const matches = (value: any, source: any, options?: MatchOptions) => {
           error =>
             `${error.message}${error.keyPath.length ? ` for "${error.keyPath.join('.')}"` : ''}`
         )
-        .join(' ')
+        .join('. ')
     : undefined;
 
   return {

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -127,7 +127,7 @@ describe('Route expectation', () => {
         cb => request.get('/foo?some=nope').end(cb),
         cb => {
           expect(expectation.verify).to.throw(
-            'Expect object did not match: Expected `"/faoo"` and value `"/foo"` not equal for "path" Expected `"value"` and value `"nope"` not equal for "query.some"'
+            'Expect object did not match: Expected `"/faoo"` and value `"/foo"` not equal for "path". Expected `"value"` and value `"nope"` not equal for "query.some"'
           );
           cb();
         }


### PR DESCRIPTION
We should period-separate multiple error messages from `match-deep`.