### PR TITLE
chore(cli): depend on @mockyeah/server

### DIFF
--- a/packages/mockyeah-cli/package.json
+++ b/packages/mockyeah-cli/package.json
@@ -57,7 +57,7 @@
     "commander": "^2.9.0",
     "inquirer": "^6.3.1",
     "liftoff": "^2.2.0",
-    "mockyeah": "^0.24.0-alpha.0",
+    "@mockyeah/server": "^0.24.0-alpha.0",
     "read-pkg-up": "^6.0.0",
     "request": "^2.87.0",
     "tildify": "^1.1.2",


### PR DESCRIPTION
Looks like with #436 we missed one dependency update.