### PR TITLE
fix: handleContentType with body as object

### DIFF
--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -53,7 +53,7 @@ const handleContentType = (body, headers) => {
   // TODO: More spec-conformant detection of JSON content type.
   if (contentType && contentType.includes('/json')) {
     return {
-      json: JSONparseSafe(body).value
+      json: _.isPlainObject(body) ? body : JSONparseSafe(body).value
     };
   }
 

--- a/packages/mockyeah/test/unit/helpers.test.js
+++ b/packages/mockyeah/test/unit/helpers.test.js
@@ -41,6 +41,18 @@ describe('app helpers', () => {
         }
       });
     });
+
+    it('gives json if already object (no parsing)', () => {
+      const body = {
+        foo: 'bar'
+      };
+      const headers = {};
+      expect(handleContentType(body, headers)).to.deep.equal({
+        raw: {
+          foo: 'bar'
+        }
+      });
+    });
   });
 
   describe('compileRoute', () => {


### PR DESCRIPTION
Updates `handleContentType` to handle cases where `body` is already an object (may have been parsed already).

This is only needed in the `v0` branch because in `master` with `v1` we always do a `fetch().text()`.