### PR TITLE
build: travis not only on master (v0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ node_js:
   - "node"
   - "lts/*"
   - "8"
-branches:
-  only:
-    - master
 cache: yarn
 script:
   - ./packages/mockyeah-tools/node_modules/.bin/prettier --check $(git ls-files | grep -E '.(js|json|md)$')


### PR DESCRIPTION
We should run Travis on more than just the `master` branch, so it also runs on the `v0` branch.