### PR TITLE
fix(cli): liftoff with new @mockyeah/server module name

### DIFF
--- a/packages/mockyeah-cli/lib/boot.js
+++ b/packages/mockyeah-cli/lib/boot.js
@@ -10,6 +10,7 @@ const checkVersionMatch = require('./checkVersionMatch');
 
 const liftoff = new Liftoff({
   name: 'mockyeah',
+  moduleName: '@mockyeah/server',
   configName: '.mockyeah',
   extensions: {},
   v8flags


### PR DESCRIPTION
When trying `npx @mockyeah/cli` for the `1.0.0-alpha.0` version, I was getting this:

```
Local mockyeah not found in /Users/me/code/mockyeah/packages/mockyeah-cli
Try running: npm install @mockyeah/server --save-dev
```

This attempts to fix that by having Liftoff look for the `@mockyeah/server` module instead.

