### PR TITLE
feat(cli): version mismatch check uses semver

### DIFF
--- a/packages/mockyeah-cli/lib/__tests__/checkVersionMatch.test.js
+++ b/packages/mockyeah-cli/lib/__tests__/checkVersionMatch.test.js
@@ -24,36 +24,138 @@ describe('checkVerisonMatch', () => {
 
     test('throws on mismatch package versions', () => {
       expect(() => {
+        const pkgUp = {
+          package: {
+            version: '0.0.0-test'
+          }
+        };
         const env = {
           modulePackage: {
             version: '99.99.99-test'
           }
         };
+        checkVersionMatch(env, pkgUp);
+      }).toThrow(
+        'Version mismatch between @mockyeah/cli@0.0.0-test and @mockyeah/server@99.99.99-test - please install compatible versions.'
+      );
+    });
+
+    test('passes on identical package versions', () => {
+      expect(() => {
         const pkgUp = {
           package: {
             version: '0.0.0-test'
           }
         };
-        checkVersionMatch(env, pkgUp);
-      }).toThrow(
-        'Version mismatch between CLI (0.0.0-test) and core (99.99.99-test) - please install same versions.'
-      );
-    });
-
-    test('passes on matching package versions', () => {
-      expect(() => {
         const env = {
           modulePackage: {
             version: '0.0.0-test'
           }
         };
+        checkVersionMatch(env, pkgUp);
+      }).not.toThrow();
+    });
+
+    test('passes on identical package versions', () => {
+      expect(() => {
         const pkgUp = {
           package: {
             version: '0.0.0-test'
           }
         };
+        const env = {
+          modulePackage: {
+            version: '0.0.0-test'
+          }
+        };
         checkVersionMatch(env, pkgUp);
       }).not.toThrow();
+    });
+
+    test('passes on different prerelease package versions', () => {
+      expect(() => {
+        const pkgUp = {
+          package: {
+            version: '0.0.1-alpha.1'
+          }
+        };
+        const env = {
+          modulePackage: {
+            version: '0.0.1-alpha.2'
+          }
+        };
+        checkVersionMatch(env, pkgUp);
+      }).not.toThrow();
+    });
+
+    test('passes on different patch package versions', () => {
+      expect(() => {
+        const env = {
+          modulePackage: {
+            version: '0.0.1'
+          }
+        };
+        const pkgUp = {
+          package: {
+            version: '0.0.2'
+          }
+        };
+        checkVersionMatch(env, pkgUp);
+      }).not.toThrow();
+    });
+
+    test('throws on different minor package versions', () => {
+      expect(() => {
+        const pkgUp = {
+          package: {
+            version: '0.1.0'
+          }
+        };
+        const env = {
+          modulePackage: {
+            version: '0.2.0'
+          }
+        };
+        checkVersionMatch(env, pkgUp);
+      }).toThrow(
+        'Version mismatch between @mockyeah/cli@0.1.0 and @mockyeah/server@0.2.0 - please install compatible versions.'
+      );
+    });
+
+    test('throws on different major package versions', () => {
+      expect(() => {
+        const pkgUp = {
+          package: {
+            version: '1.0.0'
+          }
+        };
+        const env = {
+          modulePackage: {
+            version: '2.0.0'
+          }
+        };
+        checkVersionMatch(env, pkgUp);
+      }).toThrow(
+        'Version mismatch between @mockyeah/cli@1.0.0 and @mockyeah/server@2.0.0 - please install compatible versions.'
+      );
+    });
+
+    test('throws on different major package versions with prerelease', () => {
+      expect(() => {
+        const pkgUp = {
+          package: {
+            version: '1.0.0'
+          }
+        };
+        const env = {
+          modulePackage: {
+            version: '2.0.0-alpha.0'
+          }
+        };
+        checkVersionMatch(env, pkgUp);
+      }).toThrow(
+        'Version mismatch between @mockyeah/cli@1.0.0 and @mockyeah/server@2.0.0-alpha.0 - please install compatible versions.'
+      );
     });
   });
 });

--- a/packages/mockyeah-cli/lib/checkVersionMatch.js
+++ b/packages/mockyeah-cli/lib/checkVersionMatch.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const semver = require('semver');
 
 const checkVersionMatch = (env, pkgUp) => {
   if (!pkgUp || !pkgUp.package || !pkgUp.package.version) {
@@ -14,12 +15,14 @@ const checkVersionMatch = (env, pkgUp) => {
   }
 
   const cliVersion = pkgUp.package.version;
-  const coreVersion = env.modulePackage.version;
+  const serverVersion = env.modulePackage.version;
 
-  if (cliVersion !== coreVersion) {
+  const diff = semver.diff(cliVersion, serverVersion);
+
+  if (['minor', 'major', 'preminor', 'premajor'].includes(diff)) {
     throw new Error(
       chalk.red(
-        `Version mismatch between CLI (${cliVersion}) and core (${coreVersion}) - please install same versions.`
+        `Version mismatch between @mockyeah/cli@${cliVersion} and @mockyeah/server@${serverVersion} - please install compatible versions.`
       )
     );
   }

--- a/packages/mockyeah-cli/package.json
+++ b/packages/mockyeah-cli/package.json
@@ -63,6 +63,7 @@
     "liftoff": "^2.2.0",
     "read-pkg-up": "^6.0.0",
     "request": "^2.87.0",
+    "semver": "^6.3.0",
     "v8flags": "^2.0.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating the CLI version mismatch checking to use semantic versioning instead of requiring exact match.