### PR TITLE
build: switch to npm and don't build docs on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
  - lerna bootstrap --ci
 script:
   - ./packages/mockyeah-tools/node_modules/.bin/prettier --check $(git ls-files | grep -E '.(js|json|md)$')
-  - npm test
+  - npm run test:ci
 after_success:
   - npm run test:coverage:report

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "start": "lerna run start",
     "test": "lerna run build && lerna run test",
+    "test:ci": "lerna run build:ci && lerna run test",
     "build": "lerna run build",
+    "build:ci": "lerna run build:ci",
     "test:watch": "lerna run test:watch",
     "test:unit": "lerna run test:unit",
     "test:coverage": "lerna run test:coverage",

--- a/packages/match-deep/package.json
+++ b/packages/match-deep/package.json
@@ -6,11 +6,12 @@
   "types": "dist/index.d.ts",
   "module": "src/index.js",
   "scripts": {
-    "build": "webpack && yarn build:types",
+    "build": "webpack && npm run build:types",
+    "build:ci": "npm run build",
     "build:types": "tsc --emitDeclarationOnly",
     "type-check": "tsc --noEmit",
     "lint": "eslint --max-warnings 0 src/**/*.ts",
-    "test": "yarn type-check && yarn lint && yarn test:unit",
+    "test": "npm run type-check && npm run lint && npm run test:unit",
     "test:unit": "jest"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",

--- a/packages/mockyeah-cli/package.json
+++ b/packages/mockyeah-cli/package.json
@@ -8,7 +8,7 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "test": "yarn lint && jest",
+    "test": "npm run lint && jest",
     "lint": "eslint --max-warnings 0 *.js ./bin ./lib"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",

--- a/packages/mockyeah-docs/package.json
+++ b/packages/mockyeah-docs/package.json
@@ -10,7 +10,7 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \"",
-    "docs:publish": "yarn build && cp CNAME public/CNAME && gh-pages -d public"
+    "docs:publish": "npm run build && cp CNAME public/CNAME && gh-pages -d public"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",
   "author": "Ryan Ricard",

--- a/packages/mockyeah-fetch/package.json
+++ b/packages/mockyeah-fetch/package.json
@@ -5,11 +5,12 @@
   "main": "dist/main.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "webpack && yarn build:types",
+    "build": "webpack && npm run build:types",
+    "build:ci": "npm run build",
     "build:types": "tsc --emitDeclarationOnly",
     "type-check": "tsc --noEmit",
     "lint": "eslint --max-warnings 0 src/**/*.ts",
-    "test": "yarn type-check && yarn lint && yarn test:unit",
+    "test": "npm run type-check && npm run lint && npm run test:unit",
     "test:unit": "jest"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -5,11 +5,11 @@
   "main": "index.js",
   "scripts": {
     "start": "MOCKYEAH_ROOT=. nodemon --inspect index.js",
-    "test": "yarn lint && yarn test:coverage",
-    "test:watch": "yarn test:unit --watch",
+    "test": "npm run lint && npm run test:coverage",
+    "test:watch": "npm run test:unit --watch",
     "test:unit": "mocha test/**/*Test.js test/**/*.test.js",
-    "test:coverage": "nyc yarn test:unit",
-    "test:coverage:report:html": "nyc yarn test:unit && nyc report --reporter=html",
+    "test:coverage": "nyc npm run test:unit",
+    "test:coverage:report:html": "nyc npm run test:unit && nyc report --reporter=html",
     "test:coverage:report": "nyc report --reporter=text-lcov | coveralls ../..",
     "lint": "eslint --max-warnings 0 ./app ./lib ./server ./test"
   },


### PR DESCRIPTION
The docs build is failing right now locally for some reason, so I can't run `npm run build` before publishing. There's no need to run the docs build on CI anyway for now, so decoupling build into `build` and `build:ci` versions. I'll use `build:ci` for now to build before publishing locally.