### PR TITLE
feat(fetch): cookies for dynamic responses

### DIFF
--- a/packages/mockyeah-fetch/package-lock.json
+++ b/packages/mockyeah-fetch/package-lock.json
@@ -1124,6 +1124,12 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/cookie": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+			"integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
+			"dev": true
+		},
 		"@types/eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -2458,6 +2464,11 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
+		},
+		"cookie": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",

--- a/packages/mockyeah-fetch/package.json
+++ b/packages/mockyeah-fetch/package.json
@@ -63,6 +63,7 @@
     "@babel/preset-typescript": "^7.3.3",
     "@babel/register": "^7.4.4",
     "@mockyeah/tools": "^1.0.0-alpha.4",
+    "@types/cookie": "^0.3.3",
     "@types/jest": "^24.0.18",
     "@types/lodash": "^4.14.137",
     "@types/mime": "^2.0.1",
@@ -91,6 +92,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "cookie": "^0.4.0",
     "lodash": "^4.17.15",
     "match-deep": "^1.0.0-alpha.4",
     "mime": "^2.4.4",

--- a/packages/mockyeah-fetch/src/__tests__/index.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/index.test.ts
@@ -140,4 +140,23 @@ describe('@mockyeah/fetch', () => {
     expect(response.headers.get('content-type')).toMatch('application/json');
     expect(data).toEqual({ ok: 'yes', hmm: 'sure', method: 'post' });
   });
+
+  test('should work with dynamic response checking request cookies', async () => {
+    mockyeah = new Mockyeah();
+
+    mockyeah.post('https://example.local/v1?', {
+      json: req => ({ cookieA: req.cookies.a, cookieB: req.cookies.b })
+    });
+
+    const response = await mockyeah.fetch('https://example.local/v1?ok=yes', {
+      method: 'post',
+      body: '{"hmm":"sure"}',
+      headers: {
+        'Cookie': 'a=1; b=2'
+      }
+    });
+    const data = await response.json();
+
+    expect(data).toEqual({ cookieA: '1', cookieB: '2' });
+  });
 });

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -2,6 +2,7 @@ import { parse } from 'url';
 import qs from 'qs';
 import isPlainObject from 'lodash/isPlainObject';
 import flatten from 'lodash/flatten';
+import cookie from 'cookie';
 import matches from 'match-deep';
 import { normalize } from './normalize';
 import { isMockEqual } from './isMockEqual';
@@ -241,14 +242,23 @@ class Mockyeah {
 
       const pathname = parsed.pathname || '/';
 
+      let cookies;
+
+      const cookieHeader = headers && (headers.cookie || headers.Cookie);
+      if (cookieHeader) {
+        cookies = cookie.parse(cookieHeader);
+      } else if (typeof window !== 'undefined') {
+        cookies = cookie.parse(window.document.cookie);
+      }
+
       const requestForHandler: RequestForHandler = {
         url: pathname,
         path: pathname,
         query,
         method,
         headers,
-        body: inBody
-        // TODO: `cookies, etc.
+        body: inBody,
+        cookies
       };
 
       if (matchingMock) {

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -32,6 +32,7 @@ interface RequestForHandler {
   method: Method;
   query?: Record<string, string>;
   headers?: Record<string, string>;
+  cookies?: Record<string, string>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body?: any;
 }


### PR DESCRIPTION
Adds support for `req.cookies` passed to dynamic mock response functions.

Fixes #468.