### PR TITLE
chore(fetch,match-deep): gitignore src js

### DIFF
--- a/packages/match-deep/.gitignore
+++ b/packages/match-deep/.gitignore
@@ -1,3 +1,4 @@
+src/**/*.js
 dist
 
 *.map

--- a/packages/mockyeah-fetch/.gitignore
+++ b/packages/mockyeah-fetch/.gitignore
@@ -1,3 +1,4 @@
+src/**/*.js
 dist
 
 *.map


### PR DESCRIPTION
Simply ignore `*.js` files under `src` for the packages using TypeScript.