### PR TITLE
docs: recipes and examples page: examples, deps, and tests links

### DIFF
--- a/packages/mockyeah-docs/src/menus.js
+++ b/packages/mockyeah-docs/src/menus.js
@@ -99,7 +99,7 @@ const menus = {
     { title: 'Integration', url: 'Integration' },
     {
       title: 'Recipes & Examples',
-      url: 'https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/examples'
+      url: 'Recipes-and-Examples'
     },
     { title: 'Contributing', url: 'Contributing' }
   ]

--- a/packages/mockyeah-docs/src/pages/Recipes-and-Examples.md
+++ b/packages/mockyeah-docs/src/pages/Recipes-and-Examples.md
@@ -1,0 +1,9 @@
+---
+title: Recipes & Examples
+---
+
+There are some examples includes in the [mockyeah monorepo examples directory](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/examples). GitHub tracks how [users depend on the mockyeah package](https://github.com/mockyeah/mockyeah/network/dependents?package_id=UGFja2FnZS0xNDkzNzMwNA%3D%3D).
+
+[Test Suites](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/test/mockyeah) connect to [Fixtures](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/test/fixtures) in the unit tests.
+
+The [Integration](./Integration) page has tools that connect with mockyeah.

--- a/packages/mockyeah-docs/src/pages/Recipes-and-Examples.md
+++ b/packages/mockyeah-docs/src/pages/Recipes-and-Examples.md
@@ -2,8 +2,8 @@
 title: Recipes & Examples
 ---
 
-There are some examples includes in the [mockyeah monorepo examples directory](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/examples). GitHub tracks how [users depend on the mockyeah package](https://github.com/mockyeah/mockyeah/network/dependents?package_id=UGFja2FnZS0xNDkzNzMwNA%3D%3D).
+There are some examples included in the [mockyeah monorepo examples directory](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/examples). GitHub tracks how [users depend on the mockyeah package](https://github.com/mockyeah/mockyeah/network/dependents?package_id=UGFja2FnZS0xNDkzNzMwNA%3D%3D).
 
-[Test Suites](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/test/mockyeah) connect to [Fixtures](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/test/fixtures) in the unit tests.
+Mock suites at [packages/mockyeah/test/mockyeah](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/test/mockyeah) connect to fixtures at [packages/mockyeah/test/fixtures](https://github.com/mockyeah/mockyeah/tree/master/packages/mockyeah/test/fixtures) in the unit tests.
 
 The [Integration](./Integration) page has tools that connect with mockyeah.


### PR DESCRIPTION
## What does it do?

Originally I set out to fix the URL for "Recipes & Examples" at https://mockyeah.js.org/ but you already corrected it. I added a page reviewing what we were discussing in [this issue](https://github.com/mockyeah/mockyeah/issues/484).

## How to test

`npm start` from the project root.

---

Do you want this? Is there anything else to add?