### PR TITLE
docs: update gatsby & react versions

### DIFF
--- a/packages/mockyeah-docs/package-lock.json
+++ b/packages/mockyeah-docs/package-lock.json
@@ -81,16 +81,123 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.0.tgz",
-			"integrity": "sha512-MZiB5qvTWoyiFOgootmRSDV1udjIqJW/8lmxgzKq6oDqxdmHUjeP2ZUOmgHdYjmUVNABqRrHjYAYRvj8Eox/UA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz",
+			"integrity": "sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.0",
-				"@babel/helper-member-expression-to-functions": "^7.7.0",
-				"@babel/helper-optimise-call-expression": "^7.7.0",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-member-expression-to-functions": "^7.7.4",
+				"@babel/helper-optimise-call-expression": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.0",
-				"@babel/helper-split-export-declaration": "^7.7.0"
+				"@babel/helper-replace-supers": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+					"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+					"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+					"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+					"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+					"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig=="
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
@@ -284,11 +391,11 @@
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.0.tgz",
-			"integrity": "sha512-tufDcFA1Vj+eWvwHN+jvMN6QsV5o+vUlytNKrbMiCeDL0F2j92RURzUsUMWE5EJkLyWxjdUslCsMQa9FWth16A==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.4.tgz",
+			"integrity": "sha512-EcuXeV4Hv1X3+Q1TsuOmyyxeTRiSqurGJ26+I/FW1WbymmRRapVORm6x1Zl3iDIHyRxEs+VXWp6qnlcfcJSbbw==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.7.0",
+				"@babel/helper-create-class-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -310,6 +417,15 @@
 				"@babel/plugin-syntax-json-strings": "^7.2.0"
 			}
 		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+			"integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+			}
+		},
 		"@babel/plugin-proposal-object-rest-spread": {
 			"version": "7.6.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
@@ -326,6 +442,15 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+			"integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
@@ -345,26 +470,10 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
-		"@babel/plugin-syntax-class-properties": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
-			"integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
 		"@babel/plugin-syntax-dynamic-import": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
 			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-flow": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.0.tgz",
-			"integrity": "sha512-vQMV07p+L+jZeUnvX3pEJ9EiXGCjB5CTTvsirFD9rpEuATnoAvLBLoYbw1v5tyn3d2XxSuvEKi8cV3KqYUa0vQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -385,6 +494,14 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+			"integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-syntax-object-rest-spread": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
@@ -397,6 +514,14 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
 			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+			"integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -499,15 +624,6 @@
 			"requires": {
 				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-flow-strip-types": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz",
-			"integrity": "sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-flow": "^7.2.0"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
@@ -709,14 +825,34 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
-			"integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
+			"integrity": "sha512-tajQY+YmXR7JjTwRvwL4HePqoL3DYxpYXIHKVvrOIvJmeHe2y1w4tz5qz9ObUDC9m76rCzIMPyn4eERuwA4a4A==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+					"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -869,6 +1005,15 @@
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
+		"@babel/runtime-corejs3": {
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.6.tgz",
+			"integrity": "sha512-NrRUehqG0sMSCaP+0XV/vOvvjNl4BQOWq3Qys1Q2KTEm5tGMo9h0dHnIzeKerj0a7SIB8LP5kYg/T1raE3FoKQ==",
+			"requires": {
+				"core-js-pure": "^3.0.0",
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
 		"@babel/template": {
 			"version": "7.7.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
@@ -903,29 +1048,6 @@
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
 				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@gatsbyjs/relay-compiler": {
-			"version": "2.0.0-printer-fix.4",
-			"resolved": "https://registry.npmjs.org/@gatsbyjs/relay-compiler/-/relay-compiler-2.0.0-printer-fix.4.tgz",
-			"integrity": "sha512-S2fYb2aBoBviXdtGRefBSYCuvGi2C/MmY75+XF4Ed9AzbeqEnmaKjYASbag4vagZ2n1cSQ+LMs0p0GiRDjKF0Q==",
-			"requires": {
-				"@babel/generator": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"@babel/polyfill": "^7.0.0",
-				"@babel/runtime": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@babel/types": "^7.0.0",
-				"babel-preset-fbjs": "^3.1.2",
-				"chalk": "^2.4.1",
-				"fast-glob": "^2.2.2",
-				"fb-watchman": "^2.0.0",
-				"fbjs": "^1.0.0",
-				"immutable": "~3.7.6",
-				"nullthrows": "^1.1.0",
-				"relay-runtime": "2.0.0",
-				"signedsource": "^1.0.0",
-				"yargs": "^9.0.0"
 			}
 		},
 		"@hapi/address": {
@@ -1413,6 +1535,19 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
 		},
+		"@szmarczak/http-timer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"requires": {
+				"defer-to-connect": "^1.0.1"
+			}
+		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
 		"@types/configstore": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
@@ -1498,9 +1633,9 @@
 			}
 		},
 		"@types/react": {
-			"version": "16.9.11",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.11.tgz",
-			"integrity": "sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==",
+			"version": "16.9.16",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.16.tgz",
+			"integrity": "sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
@@ -1535,51 +1670,56 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
-			"integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
+			"integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
 			"requires": {
-				"@typescript-eslint/experimental-utils": "1.13.0",
-				"eslint-utils": "^1.3.1",
+				"@typescript-eslint/experimental-utils": "2.11.0",
+				"eslint-utils": "^1.4.3",
 				"functional-red-black-tree": "^1.0.1",
-				"regexpp": "^2.0.1",
-				"tsutils": "^3.7.0"
+				"regexpp": "^3.0.0",
+				"tsutils": "^3.17.1"
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
+			"integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "1.13.0",
-				"eslint-scope": "^4.0.0"
+				"@typescript-eslint/typescript-estree": "2.11.0",
+				"eslint-scope": "^5.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
-			"integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
+			"integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "1.13.0",
-				"@typescript-eslint/typescript-estree": "1.13.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"@typescript-eslint/experimental-utils": "2.11.0",
+				"@typescript-eslint/typescript-estree": "2.11.0",
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
+			"integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
 			"requires": {
+				"debug": "^4.1.1",
+				"eslint-visitor-keys": "^1.1.0",
+				"glob": "^7.1.6",
+				"is-glob": "^4.0.1",
 				"lodash.unescape": "4.0.1",
-				"semver": "5.5.0"
+				"semver": "^6.3.0",
+				"tsutils": "^3.17.1"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -1761,9 +1901,9 @@
 			}
 		},
 		"acorn": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-			"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+			"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
 		},
 		"acorn-jsx": {
 			"version": "5.1.0",
@@ -1985,12 +2125,37 @@
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"array-includes": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+			"integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.0",
+						"string.prototype.trimright": "^2.1.0"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+				}
 			}
 		},
 		"array-iterate": {
@@ -2022,6 +2187,40 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+		},
+		"array.prototype.flat": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+			"integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.0",
+						"string.prototype.trimright": "^2.1.0"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+				}
+			}
 		},
 		"arraybuffer.slice": {
 			"version": "0.0.7",
@@ -2125,37 +2324,74 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
-		"auto-bind": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-2.1.1.tgz",
-			"integrity": "sha512-NUwV1i9D3vxxY1KnfZgSZ716d6ovY7o8LfOwLhGIPFBowIb6Ln6DBW64+jCqPzUznel2hRSkQnYQqvh7/ldw8A==",
-			"optional": true,
-			"requires": {
-				"@types/react": "^16.8.12"
-			}
-		},
 		"autoprefixer": {
-			"version": "9.7.1",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.1.tgz",
-			"integrity": "sha512-w3b5y1PXWlhYulevrTJ0lizkQ5CyqfeU6BIRDbuhsMupstHQOeb1Ur80tcB1zxSu7AwyY/qCQ7Vvqklh31ZBFw==",
+			"version": "9.7.3",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
+			"integrity": "sha512-8T5Y1C5Iyj6PgkPSFd0ODvK9DIleuPKUPYniNxybS47g2k2wFgLZ46lGQHlBuGKIAEV8fbCDfKCCRS1tvOgc3Q==",
 			"requires": {
-				"browserslist": "^4.7.2",
-				"caniuse-lite": "^1.0.30001006",
+				"browserslist": "^4.8.0",
+				"caniuse-lite": "^1.0.30001012",
 				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.21",
+				"postcss": "^7.0.23",
 				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
+					}
+				},
+				"postcss": {
+					"version": "7.0.24",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
+					"integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -2180,11 +2416,22 @@
 			}
 		},
 		"axobject-query": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
-			"integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
+			"integrity": "sha512-lF98xa/yvy6j3fBHAgQXIYl+J4eZadOSqsPojemUqClzNbBV38wWGpUbQbVEyf4eUF5yF7eHmGgGA2JiHyjeqw==",
 			"requires": {
-				"ast-types-flow": "0.0.7"
+				"@babel/runtime": "^7.7.4",
+				"@babel/runtime-corejs3": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				}
 			}
 		},
 		"babel-code-frame": {
@@ -2316,11 +2563,11 @@
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.2.0.tgz",
-			"integrity": "sha512-yeDwKaLgGdTpXL7RgGt5r6T4LmnTza/hUn5Ul8uZSGGMtEjYo13Nxai7SQaGCTEzUtg9Zq9qJn0EjEr7SeSlTQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "^6.18.0"
+				"object.assign": "^4.1.0"
 			}
 		},
 		"babel-plugin-extract-import-names": {
@@ -2332,9 +2579,9 @@
 			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.2.tgz",
-			"integrity": "sha512-Ntviq8paRTkXIxvrJBauib+2KqQbZQuh4593CEZFF8qz3IVP8VituTZmkGe6N7rsuiOIbejxXj6kx3LMlEq0UA==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
@@ -2342,24 +2589,14 @@
 			}
 		},
 		"babel-plugin-remove-graphql-queries": {
-			"version": "2.7.16",
-			"resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.16.tgz",
-			"integrity": "sha512-E2/hzXJ4VxxDDptG5ycZlEMoKdi+10NbpbbyYCmNVS1X+RH/baVPZ1x8T91aQauAqpW02uUeHTP0cpqvC2JoLw=="
-		},
-		"babel-plugin-syntax-dynamic-import": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+			"version": "2.7.19",
+			"resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+			"integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
-		},
-		"babel-plugin-syntax-trailing-function-commas": {
-			"version": "7.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
-			"integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
 		},
 		"babel-plugin-transform-object-rest-spread": {
 			"version": "6.26.0",
@@ -2375,63 +2612,804 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
 			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
 		},
-		"babel-preset-fbjs": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz",
-			"integrity": "sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==",
-			"requires": {
-				"@babel/plugin-proposal-class-properties": "^7.0.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-				"@babel/plugin-syntax-class-properties": "^7.0.0",
-				"@babel/plugin-syntax-flow": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"@babel/plugin-transform-arrow-functions": "^7.0.0",
-				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-				"@babel/plugin-transform-block-scoping": "^7.0.0",
-				"@babel/plugin-transform-classes": "^7.0.0",
-				"@babel/plugin-transform-computed-properties": "^7.0.0",
-				"@babel/plugin-transform-destructuring": "^7.0.0",
-				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
-				"@babel/plugin-transform-for-of": "^7.0.0",
-				"@babel/plugin-transform-function-name": "^7.0.0",
-				"@babel/plugin-transform-literals": "^7.0.0",
-				"@babel/plugin-transform-member-expression-literals": "^7.0.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
-				"@babel/plugin-transform-object-super": "^7.0.0",
-				"@babel/plugin-transform-parameters": "^7.0.0",
-				"@babel/plugin-transform-property-literals": "^7.0.0",
-				"@babel/plugin-transform-react-display-name": "^7.0.0",
-				"@babel/plugin-transform-react-jsx": "^7.0.0",
-				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
-				"@babel/plugin-transform-spread": "^7.0.0",
-				"@babel/plugin-transform-template-literals": "^7.0.0",
-				"babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
-			}
-		},
 		"babel-preset-gatsby": {
-			"version": "0.2.22",
-			"resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.22.tgz",
-			"integrity": "sha512-ORVZZ2cGT+JLH5szbEyDlO8+opqdZ176KaKm2Bkn/dZrN0BMkFW4ZNLHDx+gaUQyv/AqW61D+qlJUN9zSUzNKQ==",
+			"version": "0.2.26",
+			"resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+			"integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
 			"requires": {
-				"@babel/plugin-proposal-class-properties": "^7.7.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-				"@babel/plugin-transform-runtime": "^7.6.2",
-				"@babel/plugin-transform-spread": "^7.6.2",
-				"@babel/preset-env": "^7.7.1",
-				"@babel/preset-react": "^7.7.0",
-				"@babel/runtime": "^7.7.2",
+				"@babel/plugin-proposal-class-properties": "^7.7.4",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+				"@babel/plugin-proposal-optional-chaining": "^7.7.5",
+				"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+				"@babel/plugin-transform-runtime": "^7.7.6",
+				"@babel/plugin-transform-spread": "^7.7.4",
+				"@babel/preset-env": "^7.7.6",
+				"@babel/preset-react": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"babel-plugin-dynamic-import-node": "^2.3.0",
-				"babel-plugin-macros": "^2.6.1",
+				"babel-plugin-macros": "^2.8.0",
 				"babel-plugin-transform-react-remove-prop-types": "^0.4.24"
 			},
 			"dependencies": {
-				"babel-plugin-dynamic-import-node": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-					"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+				"@babel/generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+					"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
 					"requires": {
-						"object.assign": "^4.1.0"
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+					"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-builder-binary-assignment-operator-visitor": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+					"integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+					"requires": {
+						"@babel/helper-explode-assignable-expression": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-builder-react-jsx": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.4.tgz",
+					"integrity": "sha512-kvbfHJNN9dg4rkEM4xn1s8d1/h6TYNvajy9L1wx4qLn9HFg0IkTsQi4rfBe92nxrPUFcMsHoMV+8rU7MJb3fCA==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"esutils": "^2.0.0"
+					}
+				},
+				"@babel/helper-call-delegate": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+					"integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+					"integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+					"requires": {
+						"@babel/helper-regex": "^7.4.4",
+						"regexpu-core": "^4.6.0"
+					}
+				},
+				"@babel/helper-define-map": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+					"integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-explode-assignable-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+					"integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+					"requires": {
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+					"integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+					"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+					"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+					"integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-simple-access": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+					"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+					"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-wrap-function": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+					"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+					"integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+					"requires": {
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+					"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+					"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig=="
+				},
+				"@babel/plugin-proposal-async-generator-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+					"integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.7.4",
+						"@babel/plugin-syntax-async-generators": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-dynamic-import": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
+					"integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-json-strings": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+					"integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-json-strings": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
+					"integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+					"integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
+					"integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-async-generators": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+					"integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-dynamic-import": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
+					"integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-json-strings": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+					"integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-jsx": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
+					"integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-object-rest-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+					"integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-optional-catch-binding": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+					"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-top-level-await": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
+					"integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-arrow-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+					"integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+					"integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-block-scoped-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+					"integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+					"integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+					"integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-define-map": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-computed-properties": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+					"integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+					"integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
+					"integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-duplicate-keys": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+					"integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-exponentiation-operator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+					"integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+					"requires": {
+						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+					"integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+					"integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+					"integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-member-expression-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+					"integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-modules-amd": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+					"integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.5",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
+					"integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.5",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-simple-access": "^7.7.4",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-systemjs": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+					"integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-umd": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+					"integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-named-capturing-groups-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
+					"integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-new-target": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+					"integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+					"integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
+					"integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+					"requires": {
+						"@babel/helper-call-delegate": "^7.7.4",
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-property-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+					"integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-display-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.7.4.tgz",
+					"integrity": "sha512-sBbIvqYkthai0X0vkD2xsAwluBp+LtNHH+/V4a5ydifmTtb8KOVOlrMIk/MYmIc4uTYDnjZUHQildYNo36SRJw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-jsx": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.4.tgz",
+					"integrity": "sha512-LixU4BS95ZTEAZdPaIuyg/k8FiiqN9laQ0dMHB4MlpydHY53uQdWCUrwjLr5o6ilS6fAgZey4Q14XBjl5tL6xw==",
+					"requires": {
+						"@babel/helper-builder-react-jsx": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-react-jsx-self": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.7.4.tgz",
+					"integrity": "sha512-PWYjSfqrO273mc1pKCRTIJXyqfc9vWYBax88yIhQb+bpw3XChVC7VWS4VwRVs63wFHKxizvGSd00XEr+YB9Q2A==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-react-jsx-source": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.7.4.tgz",
+					"integrity": "sha512-5ZU9FnPhqtHsOXxutRtXZAzoEJwDaP32QcobbMP1/qt7NYcsCNK8XgzJcJfoEr/ZnzVvUNInNjIW22Z6I8p9mg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+					"integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
+					"requires": {
+						"regenerator-transform": "^0.14.0"
+					}
+				},
+				"@babel/plugin-transform-reserved-words": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
+					"integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-shorthand-properties": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+					"integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+					"integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-sticky-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+					"integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+					"integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-typeof-symbol": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+					"integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+					"integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
+					"integrity": "sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==",
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+						"@babel/plugin-proposal-dynamic-import": "^7.7.4",
+						"@babel/plugin-proposal-json-strings": "^7.7.4",
+						"@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+						"@babel/plugin-syntax-async-generators": "^7.7.4",
+						"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+						"@babel/plugin-syntax-json-strings": "^7.7.4",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-syntax-top-level-await": "^7.7.4",
+						"@babel/plugin-transform-arrow-functions": "^7.7.4",
+						"@babel/plugin-transform-async-to-generator": "^7.7.4",
+						"@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+						"@babel/plugin-transform-block-scoping": "^7.7.4",
+						"@babel/plugin-transform-classes": "^7.7.4",
+						"@babel/plugin-transform-computed-properties": "^7.7.4",
+						"@babel/plugin-transform-destructuring": "^7.7.4",
+						"@babel/plugin-transform-dotall-regex": "^7.7.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.7.4",
+						"@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+						"@babel/plugin-transform-for-of": "^7.7.4",
+						"@babel/plugin-transform-function-name": "^7.7.4",
+						"@babel/plugin-transform-literals": "^7.7.4",
+						"@babel/plugin-transform-member-expression-literals": "^7.7.4",
+						"@babel/plugin-transform-modules-amd": "^7.7.5",
+						"@babel/plugin-transform-modules-commonjs": "^7.7.5",
+						"@babel/plugin-transform-modules-systemjs": "^7.7.4",
+						"@babel/plugin-transform-modules-umd": "^7.7.4",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+						"@babel/plugin-transform-new-target": "^7.7.4",
+						"@babel/plugin-transform-object-super": "^7.7.4",
+						"@babel/plugin-transform-parameters": "^7.7.4",
+						"@babel/plugin-transform-property-literals": "^7.7.4",
+						"@babel/plugin-transform-regenerator": "^7.7.5",
+						"@babel/plugin-transform-reserved-words": "^7.7.4",
+						"@babel/plugin-transform-shorthand-properties": "^7.7.4",
+						"@babel/plugin-transform-spread": "^7.7.4",
+						"@babel/plugin-transform-sticky-regex": "^7.7.4",
+						"@babel/plugin-transform-template-literals": "^7.7.4",
+						"@babel/plugin-transform-typeof-symbol": "^7.7.4",
+						"@babel/plugin-transform-unicode-regex": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.4.7",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
+					}
+				},
+				"@babel/preset-react": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.4.tgz",
+					"integrity": "sha512-j+vZtg0/8pQr1H8wKoaJyGL2IEk3rG/GIvua7Sec7meXVIvGycihlGMx5xcU00kqCJbwzHs18xTu3YfREOqQ+g==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-transform-react-display-name": "^7.7.4",
+						"@babel/plugin-transform-react-jsx": "^7.7.4",
+						"@babel/plugin-transform-react-jsx-self": "^7.7.4",
+						"@babel/plugin-transform-react-jsx-source": "^7.7.4"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"browserslist": {
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"requires": {
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"core-js-compat": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
+					"integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
+					"requires": {
+						"browserslist": "^4.8.2",
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+						}
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+						}
 					}
 				}
 			}
@@ -2849,57 +3827,68 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"boxen": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-			"integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+			"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
 			"requires": {
 				"ansi-align": "^3.0.0",
 				"camelcase": "^5.3.1",
-				"chalk": "^2.4.2",
+				"chalk": "^3.0.0",
 				"cli-boxes": "^2.2.0",
-				"string-width": "^3.0.0",
-				"term-size": "^1.2.0",
-				"type-fest": "^0.3.0",
-				"widest-line": "^2.0.0"
+				"string-width": "^4.1.0",
+				"term-size": "^2.1.0",
+				"type-fest": "^0.8.1",
+				"widest-line": "^3.1.0"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+				"ansi-styles": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+					"integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
 					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
 					}
 				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
 					"requires": {
-						"ansi-regex": "^4.1.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				},
 				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
 				}
 			}
 		},
@@ -3016,14 +4005,6 @@
 			"requires": {
 				"caniuse-lite": "^1.0.30000844",
 				"electron-to-chromium": "^1.3.47"
-			}
-		},
-		"bser": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-			"requires": {
-				"node-int64": "^0.4.0"
 			}
 		},
 		"buffer": {
@@ -3274,9 +4255,9 @@
 			}
 		},
 		"camelcase": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"camelcase-css": {
 			"version": "2.0.1",
@@ -3311,14 +4292,39 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					},
+					"dependencies": {
+						"caniuse-lite": {
+							"version": "1.0.30001015",
+							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+							"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+						}
 					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -3326,11 +4332,6 @@
 			"version": "1.0.30001010",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001010.tgz",
 			"integrity": "sha512-RA5GH9YjFNea4ZQszdWgh2SC+dpLiRAg4VDQS2b5JRI45OxmbGrYocYHTa9x0bKMQUE7uvHkNPNffUr+pCxSGw=="
-		},
-		"capture-stack-trace": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -3663,58 +4664,6 @@
 				}
 			}
 		},
-		"cli-truncate": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
-			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
-			"optional": true,
-			"requires": {
-				"slice-ansi": "^1.0.0",
-				"string-width": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"optional": true
-				},
-				"slice-ansi": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-					"optional": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"optional": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
-		},
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -3766,31 +4715,41 @@
 			}
 		},
 		"cliui": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
 				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -4065,9 +5024,9 @@
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"convert-hrtime": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-2.0.0.tgz",
-			"integrity": "sha1-Gb+yyRYvnhHC8Ewsed4rfoCVxic="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
+			"integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA=="
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
@@ -4116,16 +5075,16 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"copyfiles": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-1.2.0.tgz",
-			"integrity": "sha1-qNo6xBqiIgrim9PFi2mEKU8sWTw=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.1.1.tgz",
+			"integrity": "sha512-y6DZHve80whydXzBal7r70TBgKMPKesVRR1Sn/raUu7Jh/i7iSLSyGvYaq0eMJ/3Y/CKghwzjY32q1WzEnpp3Q==",
 			"requires": {
 				"glob": "^7.0.5",
-				"ltcdr": "^2.2.1",
 				"minimatch": "^3.0.3",
 				"mkdirp": "^0.5.1",
 				"noms": "0.0.0",
-				"through2": "^2.0.1"
+				"through2": "^2.0.1",
+				"yargs": "^13.2.4"
 			}
 		},
 		"core-js": {
@@ -4158,6 +5117,11 @@
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
+		},
+		"core-js-pure": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+			"integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4195,11 +5159,6 @@
 						"json-parse-better-errors": "^1.0.1",
 						"lines-and-columns": "^1.1.6"
 					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 				}
 			}
 		},
@@ -4210,14 +5169,6 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
-			}
-		},
-		"create-error-class": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"requires": {
-				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"create-hash": {
@@ -4252,27 +5203,6 @@
 			"requires": {
 				"fbjs": "^0.8.0",
 				"gud": "^1.0.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-				},
-				"fbjs": {
-					"version": "0.8.17",
-					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-					"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-					"requires": {
-						"core-js": "^1.0.0",
-						"isomorphic-fetch": "^2.1.1",
-						"loose-envify": "^1.0.0",
-						"object-assign": "^4.1.0",
-						"promise": "^7.1.1",
-						"setimmediate": "^1.0.5",
-						"ua-parser-js": "^0.7.18"
-					}
-				}
 			}
 		},
 		"cross-fetch": {
@@ -4876,6 +5806,11 @@
 				}
 			}
 		},
+		"defer-to-connect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
+			"integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -5081,13 +6016,6 @@
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"requires": {
 				"path-type": "^4.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-				}
 			}
 		},
 		"dns-equal": {
@@ -5323,9 +6251,9 @@
 			"integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A=="
 		},
 		"elliptic": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
-			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -5459,9 +6387,9 @@
 			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
 		},
 		"envinfo": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.4.0.tgz",
-			"integrity": "sha512-FdDfnWnCVjxTTpWE3d6Jgh5JDIA3Cw7LCgpM/pI7kK1ORkjaqI2r6NqQ+ln2j0dfpgxY00AWieSvtkiZQKIItA=="
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
+			"integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ=="
 		},
 		"eol": {
 			"version": "0.8.1",
@@ -5535,52 +6463,53 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-			"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.2.tgz",
+			"integrity": "sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.9.1",
+				"ajv": "^6.10.0",
 				"chalk": "^2.1.0",
 				"cross-spawn": "^6.0.5",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
-				"eslint-scope": "^4.0.3",
-				"eslint-utils": "^1.3.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^5.0.1",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^1.4.3",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.2",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.7.0",
+				"glob-parent": "^5.0.0",
+				"globals": "^12.1.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.2.2",
-				"js-yaml": "^3.13.0",
+				"inquirer": "^7.0.0",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
+				"optionator": "^0.8.3",
 				"progress": "^2.0.0",
 				"regexpp": "^2.0.1",
-				"semver": "^5.5.1",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "^2.0.1",
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
 				"table": "^5.2.3",
-				"text-table": "^0.2.0"
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -5592,6 +6521,29 @@
 						"semver": "^5.5.0",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globals": {
+					"version": "12.3.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+					"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+					"requires": {
+						"type-fest": "^0.8.1"
 					}
 				},
 				"ignore": {
@@ -5599,22 +6551,47 @@
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
 				},
+				"regexpp": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
+				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+				},
+				"v8-compile-cache": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+					"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
 				}
 			}
 		},
 		"eslint-config-react-app": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-4.0.1.tgz",
-			"integrity": "sha512-ZsaoXUIGsK8FCi/x4lT2bZR5mMkL/Kgj+Lnw690rbvvUr/uiwgFiD8FcfAhkCycm7Xte6O5lYz4EqMx2vX7jgw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.1.0.tgz",
+			"integrity": "sha512-hBaxisHC6HXRVvxX+/t1n8mOdmCVIKgkXsf2WoUkJi7upHJTwYTsdCmx01QPOjKNT34QMQQ9sL0tVBlbiMFjxA==",
 			"requires": {
-				"confusing-browser-globals": "^1.0.7"
+				"confusing-browser-globals": "^1.0.9"
 			}
 		},
 		"eslint-import-resolver-node": {
@@ -5664,11 +6641,11 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
-			"integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
+			"integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
 			"requires": {
-				"debug": "^2.6.8",
+				"debug": "^2.6.9",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
@@ -5680,10 +6657,48 @@
 						"ms": "2.0.0"
 					}
 				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"pkg-dir": {
 					"version": "2.0.0",
@@ -5694,6 +6709,11 @@
 					}
 				}
 			}
+		},
+		"eslint-plugin-eslint-plugin": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz",
+			"integrity": "sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg=="
 		},
 		"eslint-plugin-flowtype": {
 			"version": "3.13.0",
@@ -5713,21 +6733,22 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.18.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-			"integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
+			"integrity": "sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==",
 			"requires": {
 				"array-includes": "^3.0.3",
+				"array.prototype.flat": "^1.2.1",
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
 				"eslint-import-resolver-node": "^0.3.2",
-				"eslint-module-utils": "^2.4.0",
+				"eslint-module-utils": "^2.4.1",
 				"has": "^1.0.3",
 				"minimatch": "^3.0.4",
 				"object.values": "^1.1.0",
 				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.11.0"
+				"resolve": "^1.12.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -5771,19 +6792,20 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
-			"integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz",
+			"integrity": "sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==",
 			"requires": {
 				"array-includes": "^3.0.3",
 				"doctrine": "^2.1.0",
+				"eslint-plugin-eslint-plugin": "^2.1.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.2.1",
+				"jsx-ast-utils": "^2.2.3",
 				"object.entries": "^1.1.0",
-				"object.fromentries": "^2.0.0",
+				"object.fromentries": "^2.0.1",
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.12.0"
+				"resolve": "^1.13.1"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -5792,6 +6814,14 @@
 					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 					"requires": {
 						"esutils": "^2.0.2"
+					}
+				},
+				"resolve": {
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+					"integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+					"requires": {
+						"path-parse": "^1.0.6"
 					}
 				}
 			}
@@ -5802,9 +6832,9 @@
 			"integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
 		},
 		"eslint-scope": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-			"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+			"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -5824,13 +6854,13 @@
 			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
 		},
 		"espree": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-			"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"requires": {
-				"acorn": "^6.0.7",
-				"acorn-jsx": "^5.0.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"esprima": {
@@ -5878,9 +6908,9 @@
 			}
 		},
 		"event-source-polyfill": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.9.tgz",
-			"integrity": "sha512-+x0BMKTYwZcmGmlkHK0GsXkX1+otfEwqu3QitN0wmWuHaZniw3HeIx1k5OjWX3JUHQHlPS4yONol6eokS1ZAWg=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.11.tgz",
+			"integrity": "sha512-fbo96OutP0Bb+gIYTTy8LGhNWySdetsFElCn/vhOzQL3cXWsS70TP/aRUe32U7F+PuOZH/tvb40tZgoJV8/Ilw=="
 		},
 		"eventemitter3": {
 			"version": "4.0.0",
@@ -6288,33 +7318,26 @@
 				"websocket-driver": ">=0.5.1"
 			}
 		},
-		"fb-watchman": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-			"requires": {
-				"bser": "^2.0.0"
-			}
-		},
 		"fbjs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-			"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
 			"requires": {
-				"core-js": "^2.4.1",
-				"fbjs-css-vars": "^1.0.0",
+				"core-js": "^1.0.0",
 				"isomorphic-fetch": "^2.1.1",
 				"loose-envify": "^1.0.0",
 				"object-assign": "^4.1.0",
 				"promise": "^7.1.1",
 				"setimmediate": "^1.0.5",
 				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
-		},
-		"fbjs-css-vars": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -6440,11 +7463,11 @@
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "^3.0.0"
 			}
 		},
 		"find-versions": {
@@ -7111,63 +8134,62 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
 		"gatsby": {
-			"version": "2.15.20",
-			"resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.15.20.tgz",
-			"integrity": "sha512-/z7FtYZCZLMh31Tp1sHmdoqGZFiLsSRxSbkUis2TxHFL+bfUpiHAaebKW+OOt0ILUlaGBLNVbbuwJzjxv4kxHg==",
+			"version": "2.18.11",
+			"resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.11.tgz",
+			"integrity": "sha512-q55676oJEXjVD1pY0Az+k9Q89zSzJny/tCFvYTe8rBAd6XssTLlIPoXfKn4p/hKmka09itNpxYjG2/jk9vQyTg==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/core": "^7.6.0",
-				"@babel/parser": "^7.6.0",
-				"@babel/polyfill": "^7.6.0",
-				"@babel/runtime": "^7.6.0",
-				"@babel/traverse": "^7.6.0",
-				"@gatsbyjs/relay-compiler": "2.0.0-printer-fix.4",
+				"@babel/core": "^7.7.5",
+				"@babel/parser": "^7.7.5",
+				"@babel/polyfill": "^7.7.0",
+				"@babel/runtime": "^7.7.6",
+				"@babel/traverse": "^7.7.4",
 				"@hapi/joi": "^15.1.1",
 				"@mikaelkristiansson/domready": "^1.0.9",
 				"@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
 				"@reach/router": "^1.2.1",
-				"@typescript-eslint/eslint-plugin": "^1.13.0",
-				"@typescript-eslint/parser": "^1.13.0",
+				"@typescript-eslint/eslint-plugin": "^2.11.0",
+				"@typescript-eslint/parser": "^2.11.0",
 				"address": "1.1.2",
-				"autoprefixer": "^9.6.1",
+				"autoprefixer": "^9.7.3",
 				"axios": "^0.19.0",
 				"babel-core": "7.0.0-bridge.0",
 				"babel-eslint": "^10.0.3",
 				"babel-loader": "^8.0.6",
 				"babel-plugin-add-module-exports": "^0.3.3",
-				"babel-plugin-dynamic-import-node": "^1.2.0",
-				"babel-plugin-remove-graphql-queries": "^2.7.8",
-				"babel-preset-gatsby": "^0.2.14",
+				"babel-plugin-dynamic-import-node": "^2.3.0",
+				"babel-plugin-remove-graphql-queries": "^2.7.19",
+				"babel-preset-gatsby": "^0.2.26",
 				"better-opn": "1.0.0",
 				"better-queue": "^3.8.10",
-				"bluebird": "^3.5.5",
+				"bluebird": "^3.7.2",
 				"browserslist": "3.2.8",
-				"cache-manager": "^2.10.0",
+				"cache-manager": "^2.10.1",
 				"cache-manager-fs-hash": "^0.0.7",
 				"chalk": "^2.4.2",
-				"chokidar": "3.1.1",
+				"chokidar": "3.3.0",
 				"common-tags": "^1.8.0",
 				"compression": "^1.7.4",
-				"convert-hrtime": "^2.0.0",
-				"copyfiles": "^1.2.0",
-				"core-js": "^2.6.9",
+				"convert-hrtime": "^3.0.0",
+				"copyfiles": "^2.1.1",
+				"core-js": "^2.6.11",
 				"cors": "^2.8.5",
 				"css-loader": "^1.0.1",
 				"debug": "^3.2.6",
 				"del": "^5.1.0",
 				"detect-port": "^1.3.0",
 				"devcert-san": "^0.3.3",
-				"dotenv": "^8.1.0",
-				"eslint": "^5.16.0",
-				"eslint-config-react-app": "^4.0.1",
+				"dotenv": "^8.2.0",
+				"eslint": "^6.7.2",
+				"eslint-config-react-app": "^5.1.0",
 				"eslint-loader": "^2.2.1",
 				"eslint-plugin-flowtype": "^3.13.0",
 				"eslint-plugin-graphql": "^3.1.0",
-				"eslint-plugin-import": "^2.18.2",
+				"eslint-plugin-import": "^2.19.1",
 				"eslint-plugin-jsx-a11y": "^6.2.3",
-				"eslint-plugin-react": "^7.14.3",
+				"eslint-plugin-react": "^7.17.0",
 				"eslint-plugin-react-hooks": "^1.7.0",
-				"event-source-polyfill": "^1.0.8",
+				"event-source-polyfill": "^1.0.11",
 				"express": "^4.17.1",
 				"express-graphql": "^0.9.0",
 				"fast-levenshtein": "^2.0.6",
@@ -7175,33 +8197,33 @@
 				"flat": "^4.1.0",
 				"fs-exists-cached": "1.0.0",
 				"fs-extra": "^8.1.0",
-				"gatsby-cli": "^2.7.49",
-				"gatsby-core-utils": "^1.0.10",
-				"gatsby-graphiql-explorer": "^0.2.18",
-				"gatsby-link": "^2.2.15",
-				"gatsby-plugin-page-creator": "^2.1.21",
-				"gatsby-react-router-scroll": "^2.1.9",
-				"gatsby-telemetry": "^1.1.25",
-				"glob": "^7.1.4",
+				"gatsby-cli": "^2.8.18",
+				"gatsby-core-utils": "^1.0.24",
+				"gatsby-graphiql-explorer": "^0.2.31",
+				"gatsby-link": "^2.2.27",
+				"gatsby-plugin-page-creator": "^2.1.36",
+				"gatsby-react-router-scroll": "^2.1.19",
+				"gatsby-telemetry": "^1.1.44",
+				"glob": "^7.1.6",
 				"got": "8.3.2",
-				"graphql": "^14.5.7",
-				"graphql-compose": "^6.3.5",
+				"graphql": "^14.5.8",
+				"graphql-compose": "^6.3.7",
 				"graphql-playground-middleware-express": "^1.7.12",
 				"invariant": "^2.2.4",
 				"is-relative": "^1.0.0",
 				"is-relative-url": "^3.0.0",
-				"is-wsl": "^2.1.0",
+				"is-wsl": "^2.1.1",
 				"jest-worker": "^24.9.0",
 				"json-loader": "^0.5.7",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.15",
-				"lokijs": "^1.5.7",
+				"lokijs": "^1.5.8",
 				"md5": "^2.2.1",
 				"md5-file": "^3.2.3",
 				"micromatch": "^3.1.10",
 				"mime": "^2.4.4",
 				"mini-css-extract-plugin": "^0.8.0",
-				"mitt": "^1.1.3",
+				"mitt": "^1.2.0",
 				"mkdirp": "^0.5.1",
 				"moment": "^2.24.0",
 				"name-all-modules-plugin": "^1.0.1",
@@ -7214,49 +8236,472 @@
 				"pnp-webpack-plugin": "^1.5.0",
 				"postcss-flexbugs-fixes": "^3.3.1",
 				"postcss-loader": "^2.1.6",
-				"prompts": "^2.2.1",
+				"prompts": "^2.3.0",
 				"prop-types": "^15.7.2",
 				"raw-loader": "^0.5.1",
 				"react-dev-utils": "^4.2.3",
 				"react-error-overlay": "^3.0.0",
-				"react-hot-loader": "^4.12.13",
+				"react-hot-loader": "^4.12.18",
 				"redux": "^4.0.4",
 				"redux-thunk": "^2.3.0",
 				"semver": "^5.7.1",
 				"shallow-compare": "^1.2.2",
 				"sift": "^5.1.0",
 				"signal-exit": "^3.0.2",
-				"slash": "^3.0.0",
+				"slugify": "^1.3.6",
 				"socket.io": "^2.3.0",
 				"stack-trace": "^0.0.10",
 				"string-similarity": "^1.2.2",
 				"style-loader": "^0.23.1",
-				"terser-webpack-plugin": "1.4.1",
+				"terser-webpack-plugin": "^1.4.2",
 				"true-case-path": "^2.2.1",
 				"type-of": "^2.0.1",
 				"url-loader": "^1.1.2",
 				"util.promisify": "^1.0.0",
 				"uuid": "^3.3.3",
 				"v8-compile-cache": "^1.1.2",
-				"webpack": "~4.40.2",
-				"webpack-dev-middleware": "^3.7.1",
-				"webpack-dev-server": "^3.8.1",
+				"webpack": "~4.41.2",
+				"webpack-dev-middleware": "^3.7.2",
+				"webpack-dev-server": "^3.9.0",
 				"webpack-hot-middleware": "^2.25.0",
 				"webpack-merge": "^4.2.2",
 				"webpack-stats-plugin": "^0.3.0",
-				"xstate": "^4.6.7",
+				"xstate": "^4.7.2",
 				"yaml-loader": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/core": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
+					"integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helpers": "^7.7.4",
+						"@babel/parser": "^7.7.5",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.13",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						}
+					}
+				},
+				"@babel/generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+					"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+					"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+					"requires": {
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+					"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig=="
+				},
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+						}
+					}
+				},
+				"binary-extensions": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+					"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+				},
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chokidar": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+					"integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+					"requires": {
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.1",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.2.0"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+							"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+						}
+					}
+				},
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"fsevents": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"optional": true
+				},
+				"gatsby-core-utils": {
+					"version": "1.0.24",
+					"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+					"integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+					"requires": {
+						"ci-info": "2.0.0",
+						"node-object-hash": "^2.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"is-binary-path": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+					"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+					"requires": {
+						"binary-extensions": "^2.0.0"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"readdirp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+					"requires": {
+						"picomatch": "^2.0.4"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"xstate": {
+					"version": "4.7.2",
+					"resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.2.tgz",
+					"integrity": "sha512-vAIEf5CuLPNgH5obVP7WS1U+I91L+vSKLpradVn6AhbyFrccWlNQwFVuYktInafgkvA6z4w9rLkuRKBZ5izkSA=="
+				}
+			}
+		},
+		"gatsby-cli": {
+			"version": "2.8.18",
+			"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.18.tgz",
+			"integrity": "sha512-LN0PW3OrI8QQ/9+65oNhT1gi7jJAljT4YZSbTE1mqcaSIkH8NryeccI64LcTOydHtSJFHsE2fanmmIl/nmAdgg==",
+			"requires": {
+				"@babel/code-frame": "^7.5.5",
+				"@babel/runtime": "^7.7.6",
+				"@hapi/joi": "^15.1.1",
+				"better-opn": "^1.0.0",
+				"bluebird": "^3.7.2",
+				"chalk": "^2.4.2",
+				"clipboardy": "^2.1.0",
+				"common-tags": "^1.8.0",
+				"configstore": "^5.0.0",
+				"convert-hrtime": "^3.0.0",
+				"core-js": "^2.6.11",
+				"envinfo": "^7.5.0",
+				"execa": "^3.4.0",
+				"fs-exists-cached": "^1.0.0",
+				"fs-extra": "^8.1.0",
+				"gatsby-core-utils": "^1.0.24",
+				"gatsby-telemetry": "^1.1.44",
+				"hosted-git-info": "^3.0.2",
+				"ink": "^2.6.0",
+				"ink-spinner": "^3.0.1",
+				"is-valid-path": "^0.1.1",
+				"lodash": "^4.17.15",
+				"meant": "^1.0.1",
+				"node-fetch": "^2.6.0",
+				"object.entries": "^1.1.0",
+				"opentracing": "^0.14.4",
+				"pretty-error": "^2.1.1",
+				"progress": "^2.0.3",
+				"prompts": "^2.3.0",
+				"react": "^16.12.0",
+				"redux": "^4.0.4",
+				"resolve-cwd": "^2.0.0",
+				"semver": "^6.3.0",
+				"signal-exit": "^3.0.2",
+				"source-map": "0.7.3",
+				"stack-trace": "^0.0.10",
+				"strip-ansi": "^5.2.0",
+				"update-notifier": "^3.0.1",
+				"uuid": "3.3.3",
+				"yargs": "^12.0.5",
+				"yurnalist": "^1.1.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@sindresorhus/is": {
+					"version": "0.14.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+					"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
+				"ansi-styles": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+					"integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"arrify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+					"optional": true
+				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"optional": true
+				},
+				"auto-bind": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-3.0.0.tgz",
+					"integrity": "sha512-v0A231a/lfOo6kxQtmEkdBfTApvC21aJYukA8pkKnoTvVqh3Wmm7/Rwy4GBCHTTHVoLVA5qsBDDvf1XY1nIV2g==",
+					"optional": true
+				},
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+				},
+				"boxen": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+					"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+					"requires": {
+						"ansi-align": "^3.0.0",
+						"camelcase": "^5.3.1",
+						"chalk": "^3.0.0",
+						"cli-boxes": "^2.2.0",
+						"string-width": "^4.1.0",
+						"term-size": "^2.1.0",
+						"type-fest": "^0.8.1",
+						"widest-line": "^3.1.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
+				"cacheable-request": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+					"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+					"requires": {
+						"clone-response": "^1.0.2",
+						"get-stream": "^5.1.0",
+						"http-cache-semantics": "^4.0.0",
+						"keyv": "^3.0.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
+						"responselike": "^1.0.2"
+					},
+					"dependencies": {
+						"lowercase-keys": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+							"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+						}
+					}
+				},
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+				},
+				"cli-truncate": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+					"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+					"optional": true,
+					"requires": {
+						"slice-ansi": "^3.0.0",
+						"string-width": "^4.2.0"
+					}
 				},
 				"cliui": {
 					"version": "4.1.0",
@@ -7273,6 +8718,20 @@
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -7280,8 +8739,63 @@
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
+						},
+						"wrap-ansi": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+							"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+							"requires": {
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1"
+							},
+							"dependencies": {
+								"ansi-regex": {
+									"version": "2.1.1",
+									"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+									"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+								},
+								"is-fullwidth-code-point": {
+									"version": "1.0.0",
+									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+									"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+									"requires": {
+										"number-is-nan": "^1.0.0"
+									}
+								},
+								"string-width": {
+									"version": "1.0.2",
+									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+									"requires": {
+										"code-point-at": "^1.0.0",
+										"is-fullwidth-code-point": "^1.0.0",
+										"strip-ansi": "^3.0.0"
+									}
+								},
+								"strip-ansi": {
+									"version": "3.0.1",
+									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+									"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+									"requires": {
+										"ansi-regex": "^2.0.0"
+									}
+								}
+							}
 						}
 					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
 				"configstore": {
 					"version": "5.0.0",
@@ -7295,6 +8809,16 @@
 						"write-file-atomic": "^3.0.0",
 						"xdg-basedir": "^4.0.0"
 					}
+				},
+				"convert-hrtime": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
+					"integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA=="
+				},
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"cross-spawn": {
 					"version": "7.0.1",
@@ -7311,14 +8835,6 @@
 					"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
 					"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
 				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
 				"dot-prop": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
@@ -7327,10 +8843,15 @@
 						"is-obj": "^2.0.0"
 					}
 				},
+				"envinfo": {
+					"version": "7.5.0",
+					"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
+					"integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ=="
+				},
 				"execa": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-3.3.0.tgz",
-					"integrity": "sha512-j5Vit5WZR/cbHlqU97+qcnw9WHRCIL4V1SVe75VcHcD1JRBdt8fv0zw89b7CQHQdUHTt2VjuhcF5ibAgVOxqpg==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
 					"requires": {
 						"cross-spawn": "^7.0.0",
 						"get-stream": "^5.0.0",
@@ -7352,64 +8873,37 @@
 						"locate-path": "^3.0.0"
 					}
 				},
-				"gatsby-cli": {
-					"version": "2.8.11",
-					"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.11.tgz",
-					"integrity": "sha512-pqgfpdwi8tHqCMJ/DtrBtrc2h48c7AWkLKVklFYX19cKDMyFob3nVasv20l3TqQYDsTlrVz8yBveV06mG4MQCQ==",
+				"gatsby-core-utils": {
+					"version": "1.0.24",
+					"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+					"integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+					"requires": {
+						"ci-info": "2.0.0",
+						"node-object-hash": "^2.0.0"
+					}
+				},
+				"gatsby-telemetry": {
+					"version": "1.1.44",
+					"resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+					"integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
-						"@babel/runtime": "^7.7.2",
-						"@hapi/joi": "^15.1.1",
-						"better-opn": "^1.0.0",
-						"bluebird": "^3.7.1",
-						"chalk": "^2.4.2",
-						"clipboardy": "^2.1.0",
-						"common-tags": "^1.8.0",
+						"@babel/runtime": "^7.7.6",
+						"bluebird": "^3.7.2",
+						"boxen": "^4.2.0",
 						"configstore": "^5.0.0",
-						"convert-hrtime": "^3.0.0",
-						"core-js": "^2.6.10",
-						"envinfo": "^7.4.0",
-						"execa": "^3.3.0",
-						"fs-exists-cached": "^1.0.0",
+						"envinfo": "^7.5.0",
 						"fs-extra": "^8.1.0",
-						"gatsby-core-utils": "^1.0.19",
-						"gatsby-telemetry": "^1.1.37",
-						"hosted-git-info": "^3.0.2",
-						"ink": "^2.5.0",
-						"ink-spinner": "^3.0.1",
-						"is-valid-path": "^0.1.1",
+						"gatsby-core-utils": "^1.0.24",
+						"git-up": "4.0.1",
+						"is-docker": "2.0.0",
 						"lodash": "^4.17.15",
-						"meant": "^1.0.1",
-						"node-fetch": "^2.6.0",
-						"object.entries": "^1.1.0",
-						"opentracing": "^0.14.4",
-						"pretty-error": "^2.1.1",
-						"progress": "^2.0.3",
-						"prompts": "^2.3.0",
-						"react": "^16.11.0",
-						"redux": "^4.0.4",
+						"node-fetch": "2.6.0",
 						"resolve-cwd": "^2.0.0",
-						"semver": "^6.3.0",
-						"signal-exit": "^3.0.2",
-						"source-map": "0.7.3",
+						"source-map": "^0.7.3",
 						"stack-trace": "^0.0.10",
-						"strip-ansi": "^5.2.0",
-						"update-notifier": "^2.5.0",
-						"uuid": "3.3.3",
-						"yargs": "^12.0.5",
-						"yurnalist": "^1.1.1"
-					},
-					"dependencies": {
-						"convert-hrtime": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
-							"integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA=="
-						},
-						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-						}
+						"stack-utils": "1.0.2",
+						"uuid": "3.3.3"
 					}
 				},
 				"get-stream": {
@@ -7420,6 +8914,39 @@
 						"pump": "^3.0.0"
 					}
 				},
+				"got": {
+					"version": "9.6.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+					"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+					"requires": {
+						"@sindresorhus/is": "^0.14.0",
+						"@szmarczak/http-timer": "^1.1.2",
+						"cacheable-request": "^6.0.0",
+						"decompress-response": "^3.3.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^4.1.0",
+						"lowercase-keys": "^1.0.1",
+						"mimic-response": "^1.0.1",
+						"p-cancelable": "^1.0.0",
+						"to-readable-stream": "^1.0.0",
+						"url-parse-lax": "^3.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+							"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						}
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
 				"hosted-git-info": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.2.tgz",
@@ -7428,15 +8955,58 @@
 						"lru-cache": "^5.1.1"
 					}
 				},
+				"http-cache-semantics": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+					"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+				},
+				"ink": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/ink/-/ink-2.6.0.tgz",
+					"integrity": "sha512-nD/wlSuB6WnFsFB0nUcOJdy28YvvDer3eo+gezjvZqojGA4Rx5sQpacvN//Aai83DRgwrRTyKBl5aciOcfP3zQ==",
+					"optional": true,
+					"requires": {
+						"ansi-escapes": "^4.2.1",
+						"arrify": "^2.0.1",
+						"auto-bind": "^3.0.0",
+						"chalk": "^3.0.0",
+						"cli-cursor": "^3.1.0",
+						"cli-truncate": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"lodash.throttle": "^4.1.1",
+						"log-update": "^3.0.0",
+						"prop-types": "^15.6.2",
+						"react-reconciler": "^0.24.0",
+						"scheduler": "^0.18.0",
+						"signal-exit": "^3.0.2",
+						"slice-ansi": "^3.0.0",
+						"string-length": "^3.1.0",
+						"widest-line": "^3.1.0",
+						"wrap-ansi": "^6.2.0",
+						"yoga-layout-prebuilt": "^1.9.3"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+							"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+							"optional": true,
+							"requires": {
+								"ansi-styles": "^4.1.0",
+								"supports-color": "^7.1.0"
+							}
+						}
+					}
+				},
 				"invert-kv": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
 					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
 				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				"is-npm": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+					"integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA=="
 				},
 				"is-obj": {
 					"version": "2.0.0",
@@ -7447,6 +9017,14 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				},
+				"latest-version": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+					"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+					"requires": {
+						"package-json": "^6.3.0"
+					}
 				},
 				"lcid": {
 					"version": "2.0.0",
@@ -7479,13 +9057,6 @@
 					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
 					"requires": {
 						"semver": "^6.0.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "6.3.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-						}
 					}
 				},
 				"mem": {
@@ -7507,6 +9078,11 @@
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+				},
+				"normalize-url": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
 				},
 				"npm-run-path": {
 					"version": "4.0.0",
@@ -7591,6 +9167,11 @@
 							"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 							"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 						},
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+						},
 						"shebang-command": {
 							"version": "1.2.0",
 							"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7613,6 +9194,11 @@
 							}
 						}
 					}
+				},
+				"p-cancelable": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+					"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
 				},
 				"p-finally": {
 					"version": "2.0.1",
@@ -7640,10 +9226,31 @@
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
+				"package-json": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+					"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+					"requires": {
+						"got": "^9.6.0",
+						"registry-auth-token": "^4.0.0",
+						"registry-url": "^5.0.0",
+						"semver": "^6.2.0"
+					}
+				},
 				"path-key": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"prepend-http": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 				},
 				"react": {
 					"version": "16.12.0",
@@ -7654,6 +9261,50 @@
 						"object-assign": "^4.1.1",
 						"prop-types": "^15.6.2"
 					}
+				},
+				"react-reconciler": {
+					"version": "0.24.0",
+					"resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
+					"integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
+					"optional": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.2",
+						"scheduler": "^0.18.0"
+					}
+				},
+				"registry-auth-token": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+					"integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+					"requires": {
+						"rc": "^1.2.8",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"registry-url": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+					"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+					"requires": {
+						"rc": "^1.2.8"
+					}
+				},
+				"scheduler": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+					"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+					"optional": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"shebang-command": {
 					"version": "2.0.0",
@@ -7668,32 +9319,37 @@
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
 				},
+				"slice-ansi": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+					"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+					"optional": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				},
 				"source-map": {
 					"version": "0.7.3",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
 					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
 				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+				"string-length": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+					"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+					"optional": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"astral-regex": "^1.0.0",
+						"strip-ansi": "^5.2.0"
 					},
 					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
+						"astral-regex": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+							"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+							"optional": true
 						}
 					}
 				},
@@ -7705,6 +9361,24 @@
 						"ansi-regex": "^4.1.0"
 					}
 				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"term-size": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.0.tgz",
+					"integrity": "sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg=="
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+				},
 				"unique-string": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -7713,12 +9387,301 @@
 						"crypto-random-string": "^2.0.0"
 					}
 				},
+				"update-notifier": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+					"integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+					"requires": {
+						"boxen": "^3.0.0",
+						"chalk": "^2.0.1",
+						"configstore": "^4.0.0",
+						"has-yarn": "^2.1.0",
+						"import-lazy": "^2.1.0",
+						"is-ci": "^2.0.0",
+						"is-installed-globally": "^0.1.0",
+						"is-npm": "^3.0.0",
+						"is-yarn-global": "^0.3.0",
+						"latest-version": "^5.0.0",
+						"semver-diff": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"boxen": {
+							"version": "3.2.0",
+							"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+							"integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+							"requires": {
+								"ansi-align": "^3.0.0",
+								"camelcase": "^5.3.1",
+								"chalk": "^2.4.2",
+								"cli-boxes": "^2.2.0",
+								"string-width": "^3.0.0",
+								"term-size": "^1.2.0",
+								"type-fest": "^0.3.0",
+								"widest-line": "^2.0.0"
+							}
+						},
+						"configstore": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+							"integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+							"requires": {
+								"dot-prop": "^4.1.0",
+								"graceful-fs": "^4.1.2",
+								"make-dir": "^1.0.0",
+								"unique-string": "^1.0.0",
+								"write-file-atomic": "^2.0.0",
+								"xdg-basedir": "^3.0.0"
+							}
+						},
+						"cross-spawn": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+							"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+							"requires": {
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						},
+						"crypto-random-string": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+							"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+						},
+						"dot-prop": {
+							"version": "4.2.0",
+							"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+							"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+							"requires": {
+								"is-obj": "^1.0.0"
+							}
+						},
+						"execa": {
+							"version": "0.7.0",
+							"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+							"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+							"requires": {
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
+							}
+						},
+						"get-stream": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"is-obj": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+							"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+						},
+						"is-stream": {
+							"version": "1.1.0",
+							"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+							"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+						},
+						"lru-cache": {
+							"version": "4.1.5",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+							"requires": {
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
+							}
+						},
+						"make-dir": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+							"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+							"requires": {
+								"pify": "^3.0.0"
+							}
+						},
+						"npm-run-path": {
+							"version": "2.0.2",
+							"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+							"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+							"requires": {
+								"path-key": "^2.0.0"
+							}
+						},
+						"p-finally": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+							"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+						},
+						"path-key": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+							"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+						},
+						"shebang-command": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+							"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+							"requires": {
+								"shebang-regex": "^1.0.0"
+							}
+						},
+						"shebang-regex": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+							"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"term-size": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+							"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+							"requires": {
+								"execa": "^0.7.0"
+							}
+						},
+						"type-fest": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+							"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+						},
+						"unique-string": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+							"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+							"requires": {
+								"crypto-random-string": "^1.0.0"
+							}
+						},
+						"which": {
+							"version": "1.3.1",
+							"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+							"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						},
+						"widest-line": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+							"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+							"requires": {
+								"string-width": "^2.1.1"
+							},
+							"dependencies": {
+								"string-width": {
+									"version": "2.1.1",
+									"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+									"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+									"requires": {
+										"is-fullwidth-code-point": "^2.0.0",
+										"strip-ansi": "^4.0.0"
+									}
+								},
+								"strip-ansi": {
+									"version": "4.0.0",
+									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+									"requires": {
+										"ansi-regex": "^3.0.0"
+									}
+								}
+							}
+						},
+						"write-file-atomic": {
+							"version": "2.4.3",
+							"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+							"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+							"requires": {
+								"graceful-fs": "^4.1.11",
+								"imurmurhash": "^0.1.4",
+								"signal-exit": "^3.0.2"
+							}
+						},
+						"xdg-basedir": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+							"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+							"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+						}
+					}
+				},
+				"url-parse-lax": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+					"requires": {
+						"prepend-http": "^2.0.0"
+					}
+				},
 				"which": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
-					"integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 					"requires": {
 						"isexe": "^2.0.0"
+					}
+				},
+				"widest-line": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+					"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+					"requires": {
+						"string-width": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"optional": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+							"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+							"optional": true
+						},
+						"strip-ansi": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^5.0.0"
+							}
+						}
 					}
 				},
 				"write-file-atomic": {
@@ -7759,6 +9722,35 @@
 						"which-module": "^2.0.0",
 						"y18n": "^3.2.1 || ^4.0.0",
 						"yargs-parser": "^11.1.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
 					}
 				},
 				"yargs-parser": {
@@ -7781,11 +9773,21 @@
 			}
 		},
 		"gatsby-graphiql-explorer": {
-			"version": "0.2.28",
-			"resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.28.tgz",
-			"integrity": "sha512-EVZS5L6SRBr37mbIND8hxN0wL6w1Rpln/v4ZUjapWtpRavLCppmB7dye44MSPozID324OL3saMm0YhfCeiUUUg==",
+			"version": "0.2.31",
+			"resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+			"integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
 			"requires": {
-				"@babel/runtime": "^7.7.2"
+				"@babel/runtime": "^7.7.6"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				}
 			}
 		},
 		"gatsby-image": {
@@ -7799,30 +9801,48 @@
 			}
 		},
 		"gatsby-link": {
-			"version": "2.2.24",
-			"resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.24.tgz",
-			"integrity": "sha512-8EZ0PaOfqXcSLhxATh3FbNl3wr5SUn2MdGk4jYfWkuXHAaY3Cq47icu432n5zF1T8c3zoKQEQplhTalqSRoE3Q==",
+			"version": "2.2.27",
+			"resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+			"integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
 			"requires": {
-				"@babel/runtime": "^7.7.2",
+				"@babel/runtime": "^7.7.6",
 				"@types/reach__router": "^1.2.6",
 				"prop-types": "^15.7.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				}
 			}
 		},
 		"gatsby-page-utils": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.30.tgz",
-			"integrity": "sha512-dI5K5Q6N5S7SXw4y+8Iu9+60X/orv0SXXxKxvvWHot4CuxHvV4n+nUGyf0dA/87vRBlR6mIncLnSU1JcQr1acg==",
+			"version": "0.0.35",
+			"resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+			"integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
 			"requires": {
-				"@babel/runtime": "^7.7.2",
-				"bluebird": "^3.7.1",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
 				"chokidar": "3.3.0",
 				"fs-exists-cached": "^1.0.0",
+				"gatsby-core-utils": "^1.0.24",
 				"glob": "^7.1.6",
 				"lodash": "^4.17.15",
-				"micromatch": "^3.1.10",
-				"slash": "^3.0.0"
+				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
 				"anymatch": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -7836,6 +9856,11 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
 					"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+				},
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 				},
 				"braces": {
 					"version": "3.0.2",
@@ -7873,6 +9898,15 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
 					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
 					"optional": true
+				},
+				"gatsby-core-utils": {
+					"version": "1.0.24",
+					"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+					"integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+					"requires": {
+						"ci-info": "2.0.0",
+						"node-object-hash": "^2.0.0"
+					}
 				},
 				"glob-parent": {
 					"version": "5.1.0",
@@ -8091,17 +10125,32 @@
 			}
 		},
 		"gatsby-plugin-page-creator": {
-			"version": "2.1.30",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.30.tgz",
-			"integrity": "sha512-2ChRSqj+NoKxTyk+U/0SpRpV2l7unb+xbhnV4uxlfjtCY9xo6/ysj4NnAwX8uY2WgY5zA1bDNiS+3zASN692+Q==",
+			"version": "2.1.36",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+			"integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
 			"requires": {
-				"@babel/runtime": "^7.7.2",
-				"bluebird": "^3.7.1",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
 				"fs-exists-cached": "^1.0.0",
-				"gatsby-page-utils": "^0.0.30",
+				"gatsby-page-utils": "^0.0.35",
 				"glob": "^7.1.6",
 				"lodash": "^4.17.15",
 				"micromatch": "^3.1.10"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+				}
 			}
 		},
 		"gatsby-plugin-react-helmet": {
@@ -8167,13 +10216,23 @@
 			}
 		},
 		"gatsby-react-router-scroll": {
-			"version": "2.1.16",
-			"resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.16.tgz",
-			"integrity": "sha512-1HoaAbqOO7KT5YmPAMZHnsbj6mWkfg9+Dz+v8j0HdNJ7I7YIehq3KPJL67CRLo/oRkHUw9gNulDi1LpGmkhKUA==",
+			"version": "2.1.19",
+			"resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+			"integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
 			"requires": {
-				"@babel/runtime": "^7.7.2",
+				"@babel/runtime": "^7.7.6",
 				"scroll-behavior": "^0.9.10",
 				"warning": "^3.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				}
 			}
 		},
 		"gatsby-remark-autolink-headers": {
@@ -8272,18 +10331,18 @@
 			}
 		},
 		"gatsby-telemetry": {
-			"version": "1.1.37",
-			"resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.37.tgz",
-			"integrity": "sha512-krI6P4xDCI/xMV1UT+EXZ6k+8jQiBZLWuEqt3JnrocIc8Qfa7MU7YFXn012uuZzIXejw6xQo97WE7Y1gs7bZXA==",
+			"version": "1.1.44",
+			"resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+			"integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/runtime": "^7.7.2",
-				"bluebird": "^3.7.1",
-				"boxen": "^3.2.0",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
+				"boxen": "^4.2.0",
 				"configstore": "^5.0.0",
-				"envinfo": "^7.4.0",
+				"envinfo": "^7.5.0",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.19",
+				"gatsby-core-utils": "^1.0.24",
 				"git-up": "4.0.1",
 				"is-docker": "2.0.0",
 				"lodash": "^4.17.15",
@@ -8295,6 +10354,19 @@
 				"uuid": "3.3.3"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+				},
 				"configstore": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.0.tgz",
@@ -8319,6 +10391,15 @@
 					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
 					"requires": {
 						"is-obj": "^2.0.0"
+					}
+				},
+				"gatsby-core-utils": {
+					"version": "1.0.24",
+					"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+					"integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+					"requires": {
+						"ci-info": "2.0.0",
+						"node-object-hash": "^2.0.0"
 					}
 				},
 				"is-obj": {
@@ -8841,9 +10922,9 @@
 					}
 				},
 				"fast-glob": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-					"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
+					"integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
 					"requires": {
 						"@nodelib/fs.stat": "^2.0.2",
 						"@nodelib/fs.walk": "^1.2.3",
@@ -9150,6 +11231,11 @@
 					}
 				}
 			}
+		},
+		"has-yarn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
 		},
 		"hash-base": {
 			"version": "3.0.4",
@@ -9724,11 +11810,6 @@
 				"is-cwebp-readable": "^2.0.1"
 			}
 		},
-		"immutable": {
-			"version": "3.7.6",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-			"integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
-		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -9819,106 +11900,6 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
-		"ink": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/ink/-/ink-2.5.0.tgz",
-			"integrity": "sha512-HUkVglJ11cXK+W1a5cKNoOCxLkDi5hbDMAWSFDcwF2kpNd0eoX+2/cpaTP9BTFaQ8RJk7O59NxKMmyPXkmxo7w==",
-			"optional": true,
-			"requires": {
-				"@types/react": "^16.8.6",
-				"ansi-escapes": "^4.2.1",
-				"arrify": "^1.0.1",
-				"auto-bind": "^2.0.0",
-				"chalk": "^2.4.1",
-				"cli-cursor": "^2.1.0",
-				"cli-truncate": "^1.1.0",
-				"is-ci": "^2.0.0",
-				"lodash.throttle": "^4.1.1",
-				"log-update": "^3.0.0",
-				"prop-types": "^15.6.2",
-				"react-reconciler": "^0.21.0",
-				"scheduler": "^0.15.0",
-				"signal-exit": "^3.0.2",
-				"slice-ansi": "^1.0.0",
-				"string-length": "^2.0.0",
-				"widest-line": "^2.0.0",
-				"wrap-ansi": "^5.0.0",
-				"yoga-layout-prebuilt": "^1.9.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"optional": true
-				},
-				"cli-cursor": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-					"optional": true,
-					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"optional": true
-				},
-				"restore-cursor": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-					"optional": true,
-					"requires": {
-						"onetime": "^2.0.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"slice-ansi": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-					"optional": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
-					}
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"optional": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-					"optional": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					}
-				}
-			}
-		},
 		"ink-spinner": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-3.0.1.tgz",
@@ -9935,88 +11916,29 @@
 			"integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
 		},
 		"inquirer": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
+			"integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
 			"requires": {
-				"ansi-escapes": "^3.2.0",
+				"ansi-escapes": "^4.2.1",
 				"chalk": "^2.4.2",
-				"cli-cursor": "^2.1.0",
+				"cli-cursor": "^3.1.0",
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
-				"figures": "^2.0.0",
-				"lodash": "^4.17.12",
-				"mute-stream": "0.0.7",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.15",
+				"mute-stream": "0.0.8",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
-				"string-width": "^2.1.0",
+				"string-width": "^4.1.0",
 				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
-				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"cli-cursor": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"figures": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"mute-stream": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-				},
-				"restore-cursor": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-					"requires": {
-						"onetime": "^2.0.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"strip-ansi": {
 					"version": "5.2.0",
@@ -10024,13 +11946,6 @@
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"requires": {
 						"ansi-regex": "^4.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-						}
 					}
 				}
 			}
@@ -10069,9 +11984,9 @@
 			}
 		},
 		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -10368,11 +12283,6 @@
 			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
 			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
 		},
-		"is-npm": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -10456,11 +12366,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-		},
-		"is-redirect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -10588,6 +12493,11 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
 			"integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+		},
+		"is-yarn-global": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -10810,20 +12720,12 @@
 				"webpack-sources": "^1.1.0"
 			}
 		},
-		"latest-version": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-			"requires": {
-				"package-json": "^4.0.0"
-			}
-		},
 		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "^2.0.0"
 			}
 		},
 		"leven": {
@@ -10950,11 +12852,11 @@
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"requires": {
-				"p-locate": "^2.0.0",
+				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
@@ -11305,11 +13207,6 @@
 				"yallist": "^2.1.2"
 			}
 		},
-		"ltcdr": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ltcdr/-/ltcdr-2.2.1.tgz",
-			"integrity": "sha1-Wrh60dTB2rjowIu/A37gwZAih88="
-		},
 		"make-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -11537,11 +13434,20 @@
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+				}
 			}
 		},
 		"memory-fs": {
@@ -12071,11 +13977,6 @@
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
 			"integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
 		},
-		"node-int64": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
-		},
 		"node-libs-browser": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -12112,6 +14013,11 @@
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				}
 			}
+		},
+		"node-object-hash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-2.0.0.tgz",
+			"integrity": "sha512-VZR0zroAusy1ETZMZiGeLkdu50LGjG5U1KHZqTruqtTyQ2wfWhHG2Ow4nsUbfTFGlaREgNHcCWoM/OzEm6p+NQ=="
 		},
 		"node-releases": {
 			"version": "1.1.40",
@@ -12242,11 +14148,6 @@
 			"resolved": "https://registry.npmjs.org/null-loader/-/null-loader-0.1.1.tgz",
 			"integrity": "sha1-F76av80/8OFRL2/Er8sfUDk3j64="
 		},
-		"nullthrows": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
-			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
-		},
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
@@ -12366,14 +14267,39 @@
 			}
 		},
 		"object.fromentries": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-			"integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+			"integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.15.0",
+				"es-abstract": "^1.17.0-next.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.0",
+						"string.prototype.trimright": "^2.1.0"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+				}
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -12522,13 +14448,49 @@
 			}
 		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
 			}
 		},
 		"os-tmpdir": {
@@ -12575,19 +14537,19 @@
 			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "^2.0.0"
 			}
 		},
 		"p-map": {
@@ -12648,40 +14610,9 @@
 			}
 		},
 		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-		},
-		"package-json": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-			"requires": {
-				"got": "^6.7.1",
-				"registry-auth-token": "^3.0.1",
-				"registry-url": "^3.0.3",
-				"semver": "^5.1.0"
-			},
-			"dependencies": {
-				"got": {
-					"version": "6.7.1",
-					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-					"requires": {
-						"create-error-class": "^3.0.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-redirect": "^1.0.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"lowercase-keys": "^1.0.0",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"unzip-response": "^2.0.1",
-						"url-parse-lax": "^1.0.0"
-					}
-				}
-			}
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
 		"pako": {
 			"version": "1.0.10",
@@ -12907,12 +14838,9 @@
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-			"requires": {
-				"pify": "^2.0.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
 		"pbkdf2": {
 			"version": "3.0.17",
@@ -12983,46 +14911,6 @@
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"requires": {
 				"find-up": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-				}
 			}
 		},
 		"pngjs": {
@@ -13166,19 +15054,42 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
 					}
 				},
 				"postcss-value-parser": {
 					"version": "3.3.1",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -13360,13 +15271,31 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
 					}
 				},
 				"postcss-selector-parser": {
@@ -13378,6 +15307,11 @@
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -13429,19 +15363,42 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
 					}
 				},
 				"postcss-value-parser": {
 					"version": "3.3.1",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -13677,19 +15634,42 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
 					}
 				},
 				"postcss-value-parser": {
 					"version": "3.3.1",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -13761,14 +15741,37 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
 					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -14147,9 +16150,9 @@
 			}
 		},
 		"react": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -14377,14 +16380,25 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+			"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.15.0"
+				"scheduler": "^0.18.0"
+			},
+			"dependencies": {
+				"scheduler": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+					"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				}
 			}
 		},
 		"react-error-overlay": {
@@ -14409,9 +16423,9 @@
 			}
 		},
 		"react-hot-loader": {
-			"version": "4.12.17",
-			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.17.tgz",
-			"integrity": "sha512-nee5q4Xip6+wD8DrCWxVUH0zT488K1zRG1KezJTb8oEbRO1JZvnEizbOG7BwnRfxxjk5QSyx6fPXeBf2fToBhw==",
+			"version": "4.12.18",
+			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.18.tgz",
+			"integrity": "sha512-qYD0Qi9lIbg9jLyfmodfqvAQqCBsoPKxAhca8Nxvy2/2pO5Q9r2kM28jN0bbbSnhwK8dJ7FjsfVtXKOxMW+bqw==",
 			"requires": {
 				"fast-levenshtein": "^2.0.6",
 				"global": "^4.3.0",
@@ -14439,18 +16453,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-		},
-		"react-reconciler": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.21.0.tgz",
-			"integrity": "sha512-h4Rl3L3O6G9V4Ff+F+tCXX8ElDVn0Psk/odT+NPWeA55Yk5G7+kHT8D+Q3yE+51C72LbrYcX6OfLmCZ/7Nx9cw==",
-			"optional": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.15.0"
-			}
 		},
 		"react-side-effect": {
 			"version": "1.2.0",
@@ -14492,6 +16494,16 @@
 				"load-json-file": "^2.0.0",
 				"normalize-package-data": "^2.3.2",
 				"path-type": "^2.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				}
 			}
 		},
 		"read-pkg-up": {
@@ -14501,6 +16513,46 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^2.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+				}
 			}
 		},
 		"readable-stream": {
@@ -14622,9 +16674,9 @@
 			}
 		},
 		"regexpp": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+			"integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
 		},
 		"regexpu-core": {
 			"version": "4.6.0",
@@ -14637,23 +16689,6 @@
 				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
 				"unicode-match-property-value-ecmascript": "^1.1.0"
-			}
-		},
-		"registry-auth-token": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-			"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
-			"requires": {
-				"rc": "^1.1.6",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"registry-url": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"requires": {
-				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
@@ -14674,15 +16709,6 @@
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
-			}
-		},
-		"relay-runtime": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-2.0.0.tgz",
-			"integrity": "sha512-o/LPFHTI6+3FLJXM3Ec4N6hzkKYILVHYRJThNX0UQlMnqjTVPR6NO4qFE2QzzEiUS+lys+qfnvBzSmNbSh1zWQ==",
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"fbjs": "^1.0.0"
 			}
 		},
 		"remark": {
@@ -15149,15 +17175,6 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
-		"scheduler": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
 		"schema-utils": {
 			"version": "0.4.7",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
@@ -15309,9 +17326,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
 		},
 		"serve-index": {
 			"version": "1.9.1",
@@ -15486,11 +17503,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
-		"signedsource": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
-			"integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo="
-		},
 		"simple-concat": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
@@ -15571,6 +17583,11 @@
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				}
 			}
+		},
+		"slugify": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
+			"integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
 		},
 		"snake-case": {
 			"version": "2.1.0",
@@ -15709,9 +17726,9 @@
 			}
 		},
 		"socket.io-adapter": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-			"integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+			"integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
 		},
 		"socket.io-client": {
 			"version": "2.3.0",
@@ -16202,41 +18219,14 @@
 			}
 		},
 		"stream-shift": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-		},
-		"string-length": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-			"optional": true,
-			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"optional": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
 		},
 		"string-similarity": {
 			"version": "1.2.2",
@@ -16433,13 +18423,31 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.7.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-					"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+					"version": "4.8.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001004",
-						"electron-to-chromium": "^1.3.295",
-						"node-releases": "^1.1.38"
+						"caniuse-lite": "^1.0.30001015",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.42"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001015",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+					"integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.322",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+					"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+				},
+				"node-releases": {
+					"version": "1.1.42",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+					"integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+					"requires": {
+						"semver": "^6.3.0"
 					}
 				},
 				"postcss-selector-parser": {
@@ -16451,6 +18459,11 @@
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -16639,17 +18652,14 @@
 			}
 		},
 		"term-size": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-			"requires": {
-				"execa": "^0.7.0"
-			}
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.0.tgz",
+			"integrity": "sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg=="
 		},
 		"terser": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
-			"integrity": "sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
+			"integrity": "sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==",
 			"requires": {
 				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
@@ -16664,15 +18674,15 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-			"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+			"integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
 			"requires": {
 				"cacache": "^12.0.2",
 				"find-cache-dir": "^2.1.0",
 				"is-wsl": "^1.1.0",
 				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^1.7.0",
+				"serialize-javascript": "^2.1.2",
 				"source-map": "^0.6.1",
 				"terser": "^4.1.2",
 				"webpack-sources": "^1.4.0",
@@ -16812,6 +18822,11 @@
 					}
 				}
 			}
+		},
+		"to-readable-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
 		},
 		"to-regex": {
 			"version": "3.0.2",
@@ -17290,101 +19305,10 @@
 				}
 			}
 		},
-		"unzip-response": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
-		},
 		"upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
-		},
-		"update-notifier": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-			"requires": {
-				"boxen": "^1.2.1",
-				"chalk": "^2.0.1",
-				"configstore": "^3.0.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^1.0.10",
-				"is-installed-globally": "^0.1.0",
-				"is-npm": "^1.0.0",
-				"latest-version": "^3.0.0",
-				"semver-diff": "^2.0.0",
-				"xdg-basedir": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-align": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-					"requires": {
-						"string-width": "^2.0.0"
-					}
-				},
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"boxen": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-					"requires": {
-						"ansi-align": "^2.0.0",
-						"camelcase": "^4.0.0",
-						"chalk": "^2.0.1",
-						"cli-boxes": "^1.0.0",
-						"string-width": "^2.0.0",
-						"term-size": "^1.2.0",
-						"widest-line": "^2.0.0"
-					}
-				},
-				"ci-info": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-				},
-				"cli-boxes": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-				},
-				"is-ci": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-					"requires": {
-						"ci-info": "^1.5.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
-			}
 		},
 		"upper-case": {
 			"version": "1.1.3",
@@ -17662,9 +19586,9 @@
 			"integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
 		},
 		"webpack": {
-			"version": "4.40.3",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.40.3.tgz",
-			"integrity": "sha512-sCHHpNE9XLpK4XZ/eGdjiwXBJY7KVdeVymqia1KKO3eVXNI3hwmfwEGA8vJIKop6loBbrEccysPyrtzCSwH2vw==",
+			"version": "4.41.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
+			"integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-module-context": "1.8.5",
@@ -17691,6 +19615,20 @@
 				"webpack-sources": "^1.4.1"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+					"integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
+				},
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
 				"schema-utils": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -17768,11 +19706,6 @@
 						"array-uniq": "^1.0.1"
 					}
 				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-				},
 				"chokidar": {
 					"version": "2.1.8",
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -17812,25 +19745,6 @@
 						}
 					}
 				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-						}
-					}
-				},
 				"del": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -17853,36 +19767,6 @@
 						"original": "^1.0.0"
 					}
 				},
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
 				"globby": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -17902,11 +19786,6 @@
 						}
 					}
 				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -17916,38 +19795,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
 					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"mem": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^2.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 				},
 				"normalize-path": {
 					"version": "3.0.0",
@@ -17962,41 +19809,10 @@
 						"is-wsl": "^1.1.0"
 					}
 				},
-				"os-locale": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
 				"p-map": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
 					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"pify": {
 					"version": "4.0.1",
@@ -18074,6 +19890,35 @@
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
 					}
 				},
 				"ws": {
@@ -18239,40 +20084,11 @@
 			}
 		},
 		"widest-line": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
 			"requires": {
-				"string-width": "^2.1.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"string-width": "^4.0.0"
 			}
 		},
 		"with-open-file": {
@@ -18462,30 +20278,41 @@
 			}
 		},
 		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
 				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -18620,60 +20447,74 @@
 			}
 		},
 		"yargs": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+			"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
 			"requires": {
-				"camelcase": "^4.1.0",
-				"cliui": "^3.2.0",
-				"decamelize": "^1.1.1",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"read-pkg-up": "^2.0.0",
+				"cliui": "^5.0.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^3.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^7.0.0"
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+				},
 				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"requires": {
+						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"strip-ansi": "^5.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"version": "13.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		},
 		"yauzl": {

--- a/packages/mockyeah-docs/package.json
+++ b/packages/mockyeah-docs/package.json
@@ -20,7 +20,7 @@
     "@mdx-js/mdx": "^1.4.5",
     "@mdx-js/react": "^1.4.5",
     "@mockyeah/tools": "^1.0.0-alpha.4",
-    "gatsby": "2.15.20",
+    "gatsby": "^2.18.11",
     "gatsby-image": "2.2.20",
     "gatsby-plugin-catch-links": "^2.1.10",
     "gatsby-plugin-manifest": "2.2.18",
@@ -36,12 +36,13 @@
     "gatsby-transformer-sharp": "2.2.16",
     "is-absolute-url": "^3.0.2",
     "prop-types": "15.7.2",
-    "react": "16.9.0",
-    "react-dom": "16.9.0",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
     "react-helmet": "5.2.1",
     "remark-react": "^6.0.0"
   },
   "devDependencies": {
+    "gatsby-cli": "^2.8.18",
     "prettier": "1.18.2"
   }
 }


### PR DESCRIPTION
On trying to start the `@mockyeah/docs` Gatsby locally for development, I was getting this error - I think due to old version of Gatsby CLI installed globally and older versions of React:

```
The above error occurred in the <StoreStateProvider> component:
    in StoreStateProvider
    in App

React will try to recreate this component tree from scratch using the error boundary you provided, App.
Warning: App: Error boundaries should implement getDerivedStateFromError(). In that method, return a state update to display an error message or fallback UI.
```

Inlining dependency on latest Gatsby CLI and upgrading React seemed to fix. 