### PR TITLE
build: lerna package.json postinstall and contributing docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ node_js:
   - "node"
   - "lts/*"
   - "8"
-install:
- - npm ci
- - lerna bootstrap --ci
 script:
   - ./packages/mockyeah-tools/node_modules/.bin/prettier --check $(git ls-files | grep -E '.(js|json|md)$')
   - npm run test:ci

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:coverage": "lerna run test:coverage",
     "test:coverage:report": "lerna run test:coverage:report",
     "lint": "lerna run lint",
-    "lint:watch": "lerna run lint:watch"
+    "lint:watch": "lerna run lint:watch",
+    "postinstall": "lerna bootstrap"
   },
   "devDependencies": {
     "lerna": "^3.18.4",

--- a/packages/mockyeah-docs/src/pages/Contributing.md
+++ b/packages/mockyeah-docs/src/pages/Contributing.md
@@ -32,11 +32,7 @@ Open the [docs site at http://127.0.0.1:8000](http://127.0.0.1:8000).
 Mockyeah is a monorepo project, the dev tool `lerna` is required to connect the sub-modules in the `./packages` directory. If `lerna` doesn't run when you install the dependencies you can run it manually.
 
 ```sh
-# if lerna is installed globally
-lerna bootstrap
-
-# or run it locally
-./node_modules/.bin/lerna bootstrap
+npx lerna bootstrap
 
 # continue to run, build, and test
 npm start

--- a/packages/mockyeah-docs/src/pages/Contributing.md
+++ b/packages/mockyeah-docs/src/pages/Contributing.md
@@ -17,6 +17,28 @@ $ cd mockyeah
 $ nvm install v6
 $ nvm use
 
+# install dependencies and link monorepo modules
+npm install
+npm start
+
 # if tests pass, you're good to go
 $ npm test
+```
+
+Open the [docs site at http://127.0.0.1:8000](http://127.0.0.1:8000).
+
+## Troubleshooting
+
+Mockyeah is a monorepo project, the dev tool `lerna` is required to connect the sub-modules in the `./packages` directory. If `lerna` doesn't run when you install the dependencies you can run it manually.
+
+```sh
+# if lerna is installed globally
+lerna bootstrap
+
+# or run it locally
+./node_modules/.bin/lerna bootstrap
+
+# continue to run, build, and test
+npm start
+npm test
 ```


### PR DESCRIPTION
## What does it do?

It's possible to run `lerna` right after the contributor does `npm install`. This PR adds that script into `package.json`. But, lets say we have a user that does `npm install --ignore-scripts` but they still want to help. It's no problem! On the Contributing.md docs page it will walk them through.

Bonus: docs site url

## How to test

```sh
git clone -b contributing-lerna-bootstrap https://github.com/youreadforme/mockyeah.git
cd mockyeah
npm install
```

↑ We'll notice right there it also runs lerna. I ran the unit tests locally and they didn't pass but I don't think it's related to this PR. 🤷‍♂ 