### PR TITLE
feat(fetch): log instance name and on mocking

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from './types';
 
 const debugMock = debug('mockyeah:fetch:mock');
+const debugHit = debug('mockyeah:fetch:hit');
 const debugMiss = debug('mockyeah:fetch:miss');
 const debugMissEach = debug('mockyeah:fetch:miss:each');
 const debugError = debug('mockyeah:fetch:error');
@@ -32,6 +33,7 @@ const DEFAULT_BOOT_OPTIONS: BootOptions = {};
 class Mockyeah {
   constructor(bootOptions = DEFAULT_BOOT_OPTIONS) {
     const {
+      name,
       proxy: defaultProxy,
       prependServerURL,
       noPolyfill,
@@ -48,8 +50,10 @@ class Mockyeah {
       fetch = global.fetch
     } = bootOptions;
 
+    const logPrefix = `[${name}]`;
+
     if (!fetch) {
-      const errorMessage = '@mockyeah/fetch requires a fetch implementation';
+      const errorMessage = `${logPrefix} @mockyeah/fetch requires a fetch implementation`;
       debugError(errorMessage);
       throw new Error(errorMessage);
     }
@@ -70,7 +74,7 @@ class Mockyeah {
       resObj = resObj || ({ status: 200 } as ResponseOptionsObject);
 
       if (Object.keys(resObj).some(key => !responseOptionsKeys.includes(key))) {
-        const errorMessage = `Response option(s) invalid. Options must include one of the following: ${responseOptionsKeys.join(
+        const errorMessage = `(${name}) Response option(s) invalid. Options must include one of the following: ${responseOptionsKeys.join(
           ', '
         )}`;
 
@@ -87,6 +91,9 @@ class Mockyeah {
 
     const mock = (match: Match, res?: ResponseOptions) => {
       const mockNormal = makeMock(match, res);
+
+      debugMock(`${logPrefix} mocked`, match, res);
+
       mocks.push(mockNormal);
 
       const expectation = mockNormal[0].$meta && mockNormal[0].$meta.expectation;
@@ -179,7 +186,9 @@ class Mockyeah {
 
       // TODO: Handle non-string bodies (Buffer, Form, etc.).
       if (options.body && typeof options.body !== 'string') {
-        debugError('@mockyeah/fetch does not yet support non-string request bodies, falling back to normal fetch');
+        debugError(
+          `${logPrefix} @mockyeah/fetch does not yet support non-string request bodies, falling back to normal fetch`
+        );;
         return fallbackFetch(url, init);
       }
 
@@ -199,7 +208,9 @@ class Mockyeah {
 
       // TODO: Handle `Headers` type.
       if (options.headers && !isPlainObject(options.headers)) {
-        debugError('@mockyeah/fetch does not yet support non-object request headers, falling back to normal fetch');
+        debugError(
+          `${logPrefix} @mockyeah/fetch does not yet support non-object request headers, falling back to normal fetch`
+        );
         return fallbackFetch(url, init);
       }
 
@@ -243,10 +254,14 @@ class Mockyeah {
               return true;
             }
 
-            debugMissEach('@mockyeah/fetch missed mock for', url, {
-              request: incoming,
-              mock: matchingMock
-            });
+            debugMissEach(
+              `${logPrefix} @mockyeah/fetch missed mock for`,
+              url,
+              matchResult.message,
+              {
+                request: incoming
+              }
+            );
 
             return false;
           });
@@ -281,7 +296,7 @@ class Mockyeah {
 
         const { response, json } = await respond(matchingMock, requestForHandler, bootOptions);
 
-        debugMock('@mockyeah/fetch matched mock for', url, {
+        debugHit(`${logPrefix} @mockyeah/fetch matched mock for`, url, {
           request: requestForHandler,
           response,
           json,
@@ -291,7 +306,7 @@ class Mockyeah {
         return response;
       }
 
-      debugMiss('@mockyeah/fetch missed all mocks for', url, {
+      debugMiss(`${logPrefix} @mockyeah/fetch missed all mocks for`, url, {
         request: requestForHandler
       });
 

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -33,7 +33,7 @@ const DEFAULT_BOOT_OPTIONS: BootOptions = {};
 class Mockyeah {
   constructor(bootOptions = DEFAULT_BOOT_OPTIONS) {
     const {
-      name,
+      name = 'default',
       proxy: defaultProxy,
       prependServerURL,
       noPolyfill,

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -188,7 +188,7 @@ class Mockyeah {
       if (options.body && typeof options.body !== 'string') {
         debugError(
           `${logPrefix} @mockyeah/fetch does not yet support non-string request bodies, falling back to normal fetch`
-        );;
+        );
         return fallbackFetch(url, init);
       }
 

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -1,6 +1,7 @@
 import pathToRegexp from 'path-to-regexp';
 
 interface BootOptions {
+  name?: string;
   proxy?: boolean;
   prependServerURL?: boolean;
   noPolyfill?: boolean;

--- a/packages/mockyeah/app/index.js
+++ b/packages/mockyeah/app/index.js
@@ -76,6 +76,7 @@ module.exports = function App(config) {
   const mockyeahFetch = new MockyeahFetch({
     noPolyfill: true,
     fetch,
+    name: app.config.name,
     aliases: app.config.aliases,
     responseHeaders: true, // we'll use these to coordinate logging and manually delete from response
     proxy: app.config.proxy,

--- a/packages/mockyeah/test/integration/ResponseValidationTest.js
+++ b/packages/mockyeah/test/integration/ResponseValidationTest.js
@@ -18,7 +18,7 @@ describe('Response Validation', () => {
       mockyeah.get('/some/service/end/point', { file: './fixtures/some-data.json' });
     } catch (err) {
       expect(err.message).to.equal(
-        'Response option(s) invalid. Options must include one of the following: fixture, filePath, html, json, text, status, headers, raw, latency, type'
+        '(mockyeah) Response option(s) invalid. Options must include one of the following: fixture, filePath, html, json, text, status, headers, raw, latency, type'
       );
       done();
     }


### PR DESCRIPTION
Enhances logging for `@mockyeah/fetch` by including optional instance name (defaults to `default`) as a prefix in all log and error messages.

Also adds the match miss message to those logs.

Also adds logging for when a mock is registered (and changes the debug key for hits).