### PR TITLE
feat: allow empty response

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -69,15 +69,6 @@ class Mockyeah {
       let resObj = typeof res === 'string' ? ({ text: res } as ResponseOptionsObject) : res;
       resObj = resObj || ({ status: 200 } as ResponseOptionsObject);
 
-      if (Object.keys(resObj).some(key => !responseOptionsKeys.includes(key))) {
-        const errorMessage = `Response option(s) invalid. Options must include one of the following: ${responseOptionsKeys.join(
-          ', '
-        )}`;
-
-        debugError(errorMessage);
-        throw new Error(errorMessage);
-      }
-
       if (matchNormal.$meta) {
         matchNormal.$meta.expectation = new Expectation(matchNormal);
       }

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -31,6 +31,9 @@ const requireSuite = (app, name) => {
 };
 
 const handleContentType = (body, headers) => {
+  // eslint-disable-next-line consistent-return
+  if (!body) return {};
+
   let contentType = headers['content-type'];
   contentType = Array.isArray(contentType) ? contentType[0] : contentType;
 

--- a/packages/mockyeah/app/lib/helpers.js
+++ b/packages/mockyeah/app/lib/helpers.js
@@ -31,7 +31,6 @@ const requireSuite = (app, name) => {
 };
 
 const handleContentType = (body, headers) => {
-  // eslint-disable-next-line consistent-return
   if (!body) return {};
 
   let contentType = headers['content-type'];

--- a/packages/mockyeah/test/integration/RecordFormatScriptFileTest.js
+++ b/packages/mockyeah/test/integration/RecordFormatScriptFileTest.js
@@ -101,7 +101,7 @@ describe('Record Format Script File Test', function() {
           const contents = fs.readFileSync(getSuiteFilePath(suiteName), 'utf8');
           expect(contents).to.match(
             // eslint-disable-next-line no-regex-spaces
-            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "raw": ""     }   \] ];/
+            /module\.exports = \[   \[\s+".*\/some\/service\/one"\s+\] ];/
           );
           cb();
         },
@@ -164,7 +164,7 @@ describe('Record Format Script File Test', function() {
           const contents = fs.readFileSync(getSuiteFilePath(suiteName), 'utf8');
           expect(contents).to.match(
             // eslint-disable-next-line no-regex-spaces
-            /module\.exports = \[   \[     ".*\/some\/service\/one",     {\s+"status": 206,\s+"raw": ""     }   \] ];/
+            /module\.exports = \[   \[     ".*\/some\/service\/one",     {\s+"status": 206\s+}   \] ];/
           );
           cb();
         },

--- a/packages/mockyeah/test/integration/RecordFormatScriptFunctionTest.js
+++ b/packages/mockyeah/test/integration/RecordFormatScriptFunctionTest.js
@@ -102,7 +102,7 @@ describe('Record Format Script Function Test', function() {
           const contents = fs.readFileSync(getSuiteFilePath(suiteName), 'utf8');
           expect(contents).to.match(
             // eslint-disable-next-line no-regex-spaces
-            /module\.exports = \[   \[     ".*\/some\/service\/one",     {       "raw": ""     }   \] ];/
+            /module\.exports = \[   \[\s+".*\/some\/service\/one"\s+\] ];/
           );
           cb();
         },

--- a/packages/mockyeah/test/integration/ResponseValidationTest.js
+++ b/packages/mockyeah/test/integration/ResponseValidationTest.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { expect } = require('chai');
 const TestHelper = require('../TestHelper');
 
 const { mockyeah, request } = TestHelper;
@@ -10,19 +9,5 @@ describe('Response Validation', () => {
     mockyeah.get('/some/service/end/point', 'hey there');
 
     request.get('/some/service/end/point').expect(200, 'hey there', done);
-  });
-
-  it('should validate response option(s) are correct', done => {
-    try {
-      // Use incorrect option 'file'
-      mockyeah.get('/some/service/end/point', { file: './fixtures/some-data.json' });
-    } catch (err) {
-      expect(err.message).to.equal(
-        'Response option(s) invalid. Options must include one of the following: fixture, filePath, html, json, text, status, headers, raw, latency, type'
-      );
-      done();
-    }
-
-    request.get('/some/service/end/point').expect(404);
   });
 });


### PR DESCRIPTION
Don't require specifying any response data - defaults to empty string.