### PR TITLE
fix: test packages no websocket

### DIFF
--- a/packages/mockyeah-test-jest/index.js
+++ b/packages/mockyeah-test-jest/index.js
@@ -1,7 +1,9 @@
 require('isomorphic-fetch');
 const Mockyeah = require('@mockyeah/fetch');
 
-const mockyeah = new Mockyeah();
+const mockyeah = new Mockyeah({
+  noWebSocket: true
+});
 
 afterEach(() => mockyeah.reset());
 

--- a/packages/mockyeah-test-mocha/index.js
+++ b/packages/mockyeah-test-mocha/index.js
@@ -1,7 +1,9 @@
 require('isomorphic-fetch');
 const Mockyeah = require('@mockyeah/fetch');
 
-const mockyeah = new Mockyeah();
+const mockyeah = new Mockyeah({
+  noWebSocket: true
+});
 
 afterEach(() => mockyeah.reset());
 


### PR DESCRIPTION
We don't want to use the `WebSocket` functionality in the test packages.