### PR TITLE
fix(fetch): full meta original normal

### DIFF
--- a/packages/mockyeah-fetch/src/__tests__/normalize.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/normalize.test.ts
@@ -1,0 +1,12 @@
+import { normalize } from '../normalize';
+
+describe('normalize', () => {
+  test('parse query', () => {
+    expect(normalize('/v1?ok=yes')).toMatchObject({
+      query: {
+        ok: 'yes'
+      }
+    });
+  });
+});
+g;

--- a/packages/mockyeah-fetch/src/__tests__/normalize.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/normalize.test.ts
@@ -8,5 +8,17 @@ describe('normalize', () => {
       }
     });
   });
+
+  test('original normal', () => {
+    expect(normalize('/v1?ok=yes')).toMatchObject({
+      $meta: {
+        originalNormal: {
+          url: '/v1',
+          query: {
+            ok: 'yes'
+          }
+        }
+      }
+    });
+  });
 });
-g;

--- a/packages/mockyeah-fetch/src/normalize.ts
+++ b/packages/mockyeah-fetch/src/normalize.ts
@@ -58,7 +58,7 @@ const makeRequestUrl = (url: string) => {
     : url;
 };
 
-const normalize = (match: Match, incoming?: boolean) => {
+const normalize = (match: Match, incoming?: boolean): Match => {
   if (typeof match === 'function') return match;
 
   const originalMatch = isPlainObject(match) ? { ...(match as MatchObject) } : match;

--- a/packages/mockyeah-fetch/src/normalize.ts
+++ b/packages/mockyeah-fetch/src/normalize.ts
@@ -58,7 +58,7 @@ const makeRequestUrl = (url: string) => {
     : url;
 };
 
-const normalize = (match: Match, incoming?: boolean): Match => {
+const normalize = (match: Match, incoming?: boolean): MatchObject => {
   if (typeof match === 'function') return match;
 
   const originalMatch = isPlainObject(match) ? { ...(match as MatchObject) } : match;
@@ -91,14 +91,7 @@ const normalize = (match: Match, incoming?: boolean): Match => {
     match.method = match.method.toLowerCase() as Method;
   }
 
-  const originalNormal = {
-    ...match
-  };
-
   const $meta = { ...(match.$meta || {}) };
-
-  $meta.original = originalMatch;
-  $meta.originalNormal = originalNormal;
 
   if (match.path) {
     match.url = match.path;
@@ -117,8 +110,19 @@ const normalize = (match: Match, incoming?: boolean): Match => {
     match.url = stripped.url.replace(/\/+$/, '');
     match.url = match.url || '/';
 
-    originalNormal.url = match.url;
+    match.query = isPlainObject(match.query)
+      ? { ...stripped.query, ...match.query }
+      : match.query || stripped.query;
+  }
 
+  const originalNormal = {
+    ...match
+  };
+
+  $meta.original = originalMatch;
+  $meta.originalNormal = originalNormal;
+
+  if (typeof match.url === 'string') {
     if (!incoming) {
       const matchKeys: pathToRegexp.Key[] = [];
       // `pathToRegexp` mutates `matchKeys` to contain a list of named parameters
@@ -128,10 +132,6 @@ const normalize = (match: Match, incoming?: boolean): Match => {
       $meta.matchKeys = matchKeys;
       $meta.fn = match.url.toString();
     }
-
-    match.query = isPlainObject(match.query)
-      ? { ...stripped.query, ...match.query }
-      : match.query || stripped.query;
   } else if (isRegExp(match.url)) {
     if (!incoming) {
       const regex = match.url;


### PR DESCRIPTION
Fixes `match.$meta.originalNormal` to include query parsed from URL string and other bits we missed. This was causes routes with same paths but different queries to clobber each other on mounting.