### PR TITLE
fix(fetch): body always empty string

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -369,7 +369,7 @@ class Mockyeah {
       if (responseHeaders) {
         headers['x-mockyeah-missed'] = 'true';
       }
-      return new Response(undefined, {
+      return new Response('', {
         status: 404,
         headers
       });

--- a/packages/mockyeah-fetch/src/parseBody.ts
+++ b/packages/mockyeah-fetch/src/parseBody.ts
@@ -1,9 +1,9 @@
 const parseBody = async (res: Response) => {
   const { status } = res;
 
-  if (status === 204) return undefined;
+  if (status === 204) return '';
 
-  return res.text() || undefined;
+  return res.text() || '';
 };
 
 export { parseBody };


### PR DESCRIPTION
Looks like some other libraries can't handle `undefined` string. Perhaps it should've been `null`. To be safe, we'll just always return an empty string in these cases for now.