### PR TITLE
fix(fetch): expect params default object

### DIFF
--- a/packages/mockyeah-fetch/src/Expectation.ts
+++ b/packages/mockyeah-fetch/src/Expectation.ts
@@ -187,7 +187,7 @@ class Expectation {
     const message = `${this.prefix} Params did not match expected`;
 
     this.handlers.push(req => {
-      matchesAssertion(req.query, value, message);
+      matchesAssertion(req.query || {}, value || {}, message);
     });
 
     return this;


### PR DESCRIPTION
In some cases, expectations were failing due to `{}` not equaling `undefined`, so we'll always default to empty objects when comparing params.