### PR TITLE
fix(fetch): optional fetch init & response options

### DIFF
--- a/packages/mockyeah-fetch/src/__tests__/index.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/index.test.ts
@@ -7,7 +7,7 @@ global.fetch = jest.fn();
 window.fetch = global.fetch;
 
 describe('@mockyeah/fetch', () => {
-  let mockyeah;
+  let mockyeah: Mockyeah;
 
   afterEach(() => {
     if (mockyeah) mockyeah.reset();
@@ -50,6 +50,18 @@ describe('@mockyeah/fetch', () => {
 
     expect(response.headers.get('content-type')).toMatch('application/json');
     expect(data).toEqual({ a: 1 });
+  });
+
+  test('should work with no response options', async () => {
+    mockyeah = new Mockyeah();
+
+    mockyeah.mock('*');
+
+    const response = await mockyeah.fetch('https://example.local');
+    const data = await response.text();
+
+    expect(response.status).toEqual(200);
+    expect(data).toEqual('');
   });
 
   test('should work with only wildcard', async () => {

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -150,7 +150,7 @@ class Mockyeah {
       global.fetch = this.fetch.bind(this);
     }
 
-    const methods = ({
+    const methods = {
       all: this.all.bind(this),
       get: this.get.bind(this),
       post: this.post.bind(this),
@@ -158,14 +158,14 @@ class Mockyeah {
       delete: this.delete.bind(this),
       options: this.options.bind(this),
       patch: this.patch.bind(this)
-    });
+    };
 
     this.methods = methods;
   }
 
   async fetch(
     input: RequestInfo,
-    init: RequestInit,
+    init?: RequestInit,
     fetchOptions: FetchOptions = {}
   ): Promise<Response> {
     const { logPrefix, mocks, bootOptions, aliasReplacements } = this.__private;
@@ -358,7 +358,7 @@ class Mockyeah {
     return this.fallbackFetch(url, newOptions, { noProxy });
   }
 
-  async fallbackFetch(input: RequestInfo, init: RequestInit, fetchOptions: FetchOptions = {}) {
+  async fallbackFetch(input: RequestInfo, init?: RequestInit, fetchOptions: FetchOptions = {}) {
     const { noProxy } = fetchOptions;
     const { responseHeaders } = this.__private.bootOptions;
 

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -59,12 +59,12 @@ interface ResponseOptionsObject {
   text?: Responder<string>;
   html?: Responder<string>;
   raw?: Responder<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
-  filePath: Responder<string>;
-  fixture: Responder<string>;
+  filePath?: Responder<string>;
+  fixture?: Responder<string>;
   status?: Responder<number>;
   type?: Responder<string>;
   latency?: Responder<number>;
-  headers: Record<string, string>;
+  headers?: Record<string, string>;
 }
 
 const responseOptionsKeys = [
@@ -80,7 +80,7 @@ const responseOptionsKeys = [
   'type'
 ];
 
-type ResponseOptions = string | ResponseOptionsObject;
+type ResponseOptions = string | ResponseOptionsObject | undefined;
 
 type Matcher<T> = T | ((arg: T) => boolean | undefined);
 type MatchString<T = string> = Matcher<T> | RegExp;


### PR DESCRIPTION
Fix up types to allow optional response body, response body fields, and fetch init object. Also add a test proving no response options are needed.