### PR TITLE
feat(fetch): match cookies

### DIFF
--- a/packages/mockyeah-fetch/src/__tests__/index.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/index.test.ts
@@ -76,6 +76,43 @@ describe('@mockyeah/fetch', () => {
     expect(data).toEqual({ a: 1 });
   });
 
+  test('should match cookie header', async () => {
+    mockyeah = new Mockyeah({ noProxy: true });
+
+    mockyeah.mock({
+      cookies: {
+        ok: 'yes'
+      }
+    }, { text: 'ok' });
+
+    const response = await mockyeah.fetch('https://example.local', {
+      headers: {
+        Cookie: 'ok=yes'
+      }
+    });
+    const data = await response.text();
+
+    expect(data).toEqual('ok');
+  });
+
+  test('should fail to match cookie header', async () => {
+    mockyeah = new Mockyeah({ noProxy: true });
+
+    mockyeah.mock({
+      cookies: {
+        ok: 'yes'
+      }
+    }, { text: 'ok' });
+
+    const response = await mockyeah.fetch('https://example.local', {
+      headers: {
+        Cookie: 'ok=no'
+      }
+    });
+
+    expect(response.status).toEqual(404);
+  });
+
   test('should work with regex', async () => {
     mockyeah = new Mockyeah();
 

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -242,12 +242,26 @@ class Mockyeah {
 
     const headers = options.headers as Record<string, string>;
 
+    let cookies;
+
+    try {
+      const cookieHeader = headers && (headers.cookie || headers.Cookie);
+      if (cookieHeader) {
+        cookies = cookie.parse(cookieHeader);
+      } else if (typeof window !== 'undefined') {
+        cookies = cookie.parse(window.document.cookie);
+      }
+    } catch (error) {
+      debugError(`${logPrefix} @mockyeah/fetch couldn't parse cookies: ${error.message}`);
+    }
+
     const incoming = {
       url: url.replace(ignorePrefix, ''),
       query,
       headers,
       body: inBody,
-      method
+      method,
+      cookies
     };
 
     let matchingMock: MockNormal | undefined;
@@ -290,15 +304,6 @@ class Mockyeah {
       });
 
     const pathname = parsed.pathname || '/';
-
-    let cookies;
-
-    const cookieHeader = headers && (headers.cookie || headers.Cookie);
-    if (cookieHeader) {
-      cookies = cookie.parse(cookieHeader);
-    } else if (typeof window !== 'undefined') {
-      cookies = cookie.parse(window.document.cookie);
-    }
 
     const requestForHandler: RequestForHandler = {
       url: pathname,

--- a/packages/mockyeah-fetch/src/isMockEqual.ts
+++ b/packages/mockyeah-fetch/src/isMockEqual.ts
@@ -18,8 +18,9 @@ const isMockEqual = (match1: MatchObject, match2: MatchObject) => {
     on1.method === on2.method &&
     isEqual(on1.query, on2.query) &&
     isEqual(on1.body, on2.body) &&
-    isEqual(on1.headers, on2.headers)
-  );
+    isEqual(on1.headers, on2.headers) &&
+    isEqual(on1.cookies, on2.cookies)
+);
 };
 
 export { isMockEqual };

--- a/packages/mockyeah-fetch/src/normalize.ts
+++ b/packages/mockyeah-fetch/src/normalize.ts
@@ -115,6 +115,14 @@ const normalize = (match: Match, incoming?: boolean): MatchObject => {
       : match.query || stripped.query;
   }
 
+  if (isEmpty(match.query)) {
+    delete match.query;
+  }
+
+  if (isEmpty(match.cookies)) {
+    delete match.cookies;
+  }
+
   const originalNormal = {
     ...match
   };

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -127,6 +127,7 @@ interface MatchObject {
   method?: MatchString<MethodOrAll>;
   query?: Matcher<Record<string, MatchString>>;
   headers?: Matcher<Record<string, MatchString>>;
+  cookies?: Matcher<Record<string, MatchString>>;
   // TODO: Type out `body`.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body?: any;


### PR DESCRIPTION
Adds support to `@mockyeah/fetch` for mocks to match against a `cookies` object, which we pull from `headers` on the request if available, else from `document.cookies` in `window`ed environment like the browser.

For example, this would match any request with the cookie `say` with value `hi`:
```ts
mockyeah.get({
  cookies: {
    say: 'hi'
  }
}, { text 'hi!' })
```

Fixes #473.
