### PR TITLE
feat(fetch): dynamic mock suite resolver

### DIFF
--- a/packages/mockyeah-fetch/src/isMockEqual.ts
+++ b/packages/mockyeah-fetch/src/isMockEqual.ts
@@ -20,7 +20,7 @@ const isMockEqual = (match1: MatchObject, match2: MatchObject) => {
     isEqual(on1.body, on2.body) &&
     isEqual(on1.headers, on2.headers) &&
     isEqual(on1.cookies, on2.cookies)
-);
+  );
 };
 
 export { isMockEqual };

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -21,6 +21,7 @@ interface BootOptions {
   responseHeaders?: boolean;
   fileResolver?: (filePath: string) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   fixtureResolver?: (filePath: string) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  mockSuiteResolver?: MockSuiteResolver;
 }
 
 interface ConnectWebSocketOptions {
@@ -145,6 +146,10 @@ type Match = string | RegExp | MatchNormal;
 
 type Mock = [Match, ResponseOptions];
 
+type MockSuite = Mock[];
+
+type MockSuiteResolver = (suiteName: string) => Promise<{ default: MockSuite }>;
+
 type MockNormal = [MatchNormal, ResponseOptionsObject];
 
 interface MockReturn {
@@ -155,6 +160,7 @@ type MockFunction = (match: Match, res?: ResponseOptions) => MockReturn;
 
 interface FetchOptions {
   dynamicMocks?: Mock[];
+  dynamicMockSuite?: string;
   noProxy?: boolean;
 }
 
@@ -181,6 +187,8 @@ export {
   MatchObject,
   MatchString,
   Mock,
+  MockSuite,
+  MockSuiteResolver,
   MockNormal,
   MockFunction,
   MockReturn,


### PR DESCRIPTION
Adds a config option to specify a dynamic mock suite resolver. Which suite(s) to resolve comes from either the `dynamicMockSuite` option on `mockyeah.fetch`, or from the cookie specified in `config.suiteCookie` (default `mockyeahSuite`).

Fixes #482.
