### PR TITLE
fix(fetch): only add suite header when prepending server url

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -373,26 +373,28 @@ class Mockyeah {
 
     const serverUrl = `http${portHttps ? 's' : ''}://${host}:${portHttps || port}`;
 
+    let newOptions = options;
+
     // Consider removing this `prependServerURL` feature.
     if (prependServerURL && serverUrl) {
       url = `${serverUrl}/${url.replace('://', '~~~')}`;
-    }
 
-    let suiteName;
-    if (typeof document !== 'undefined') {
-      const m = document.cookie.match(`\\b${suiteCookie}=([^;]+)\\b`);
-      suiteName = m && m[1];
-    }
-
-    const newOptions = {
-      ...options,
-      headers: {
-        ...options.headers,
-        ...(suiteName && {
-          [suiteHeader]: suiteName
-        })
+      let suiteName;
+      if (typeof document !== 'undefined') {
+        const m = document.cookie.match(`\\b${suiteCookie}=([^;]+)\\b`);
+        suiteName = m && m[1];
       }
-    };
+
+      newOptions = {
+        ...options,
+        headers: {
+          ...options.headers,
+          ...(suiteName && {
+            [suiteHeader]: suiteName
+          })
+        }
+      };
+    }
 
     return this.fallbackFetch(url, newOptions, { noProxy });
   }


### PR DESCRIPTION
Only adds suite header to fallback fetches when prepending server URL. This was originally written to support dynamic mocks with server integration. We may remove the server integration feature someday.