### PR TITLE
fix(fetch): no retries on blocking fetch websocket

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -554,19 +554,17 @@ class Mockyeah {
 
     debugAdmin(`WebSocket trying to connect to '${webSocketUrl}'.`);
 
+    try {
+      this.__private.ws = new WebSocket(webSocketUrl);
+    } catch (error) {
+      debugAdminError(`WebSocket couldn't connect to '${webSocketUrl}':`, error);
+
+      delete this.__private.ws;
+
+      throw error;
+    }
+
     await new Promise((resolve, reject) => {
-      try {
-        this.__private.ws = new WebSocket(webSocketUrl);
-      } catch (error) {
-        debugAdminError(`WebSocket couldn't connect to '${webSocketUrl}':`, error);
-
-        delete this.__private.ws;
-
-        reject(error);
-
-        return;
-      }
-
       const { ws } = this.__private;
 
       if (ws) {

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -188,7 +188,7 @@ class Mockyeah {
 
     if (!noWebSocket) {
       try {
-        await this.connectWebSocket();
+        await this.connectWebSocket({ retries: 0 });
       } catch (error) {
         // silence
       }
@@ -559,6 +559,12 @@ class Mockyeah {
         this.__private.ws = new WebSocket(webSocketUrl);
       } catch (error) {
         debugAdminError(`WebSocket couldn't connect to '${webSocketUrl}':`, error);
+
+        delete this.__private.ws;
+
+        reject(error);
+
+        return;
       }
 
       const { ws } = this.__private;
@@ -572,7 +578,7 @@ class Mockyeah {
 
         ws.onerror = error => {
           debugAdminError('WebSocket errored', error);
-          reject();
+          reject(error);
         };
 
         ws.onclose = () => {
@@ -589,7 +595,7 @@ class Mockyeah {
             }, webSocketReconnectInterval);
           }
 
-          reject();
+          reject(new Error('WebSocket closed'));
         };
 
         ws.onmessage = (event: MessageEvent) => {


### PR DESCRIPTION
The fetch-blocking websocket connection attempt shouldn't retry.

Also enhances some error handling for websocket.