### PR TITLE
fix(server): send record after connect

### DIFF
--- a/packages/mockyeah/server/withAdminServer.js
+++ b/packages/mockyeah/server/withAdminServer.js
@@ -41,6 +41,11 @@ const withAdminServer = ({ app, instance }) => {
       });
 
       ws.send(JSON.stringify({ type: 'connected' }));
+
+      // In case we didn't connect before the record event, send it again.
+      if (app.locals.recording) {
+        onRecord();
+      }
     });
   }
 };


### PR DESCRIPTION
Send record event after connection in case we don't connect before the event was sent.