### PR TITLE
fix(fetch): stop recording on websocket close

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -576,6 +576,8 @@ class Mockyeah {
           delete this.__private.ws;
 
           reject(new Error('WebSocket closed'));
+
+          this.__private.recording = false;
         };
 
         ws.onmessage = (event: MessageEvent) => {

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -573,11 +573,11 @@ class Mockyeah {
         ws.onclose = () => {
           debugAdminError('WebSocket closed');
 
+          this.__private.recording = false;
+
           delete this.__private.ws;
 
           reject(new Error('WebSocket closed'));
-
-          this.__private.recording = false;
         };
 
         ws.onmessage = (event: MessageEvent) => {


### PR DESCRIPTION
In case the websocket server closes, we should reset the recording flag back to false.