### PR TITLE
chore: prettify lerna.json on postversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:coverage:report": "lerna run test:coverage:report",
     "lint": "lerna run lint",
     "lint:watch": "lerna run lint:watch",
-    "postinstall": "lerna bootstrap"
+    "postinstall": "lerna bootstrap",
+    "postversion": "prettier --write lerna.json"
   },
   "devDependencies": {
     "lerna": "^3.18.4",


### PR DESCRIPTION
Formats `lerna.json` with `prettier` after `lerna version` using the top-level `postversion` hook (hoping this works).
