### PR TITLE
fix(fetch): fallback uses options fetch not global

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -391,7 +391,7 @@ class Mockyeah {
 
   async fallbackFetch(input: RequestInfo, init?: RequestInit, fetchOptions: FetchOptions = {}) {
     const { noProxy } = fetchOptions;
-    const { responseHeaders } = this.__private.bootOptions;
+    const { responseHeaders, fetch } = this.__private.bootOptions;
 
     const url = typeof input === 'string' ? input : input.url;
 


### PR DESCRIPTION
We should've been using `bootOptions.fetch` instead of global `fetch` in the fallback method.