### PR TITLE
fix(fetch): fallback to type if no mime type mapping

### DIFF
--- a/packages/mockyeah-docs/src/pages/API/Mock-API.md
+++ b/packages/mockyeah-docs/src/pages/API/Mock-API.md
@@ -154,6 +154,7 @@ Response options informing mockyeah how to respond to matching requests. Support
 - `json` (`Object|Function|Promise`; optional) - JSON to include in response body. Assumes response Content-Type of `application/json`.
 - `raw` (`String|Function|Promise`; optional) - Text to include in response body. Content-Type is the default Express type if not specified in header.
 - `text` (`String|Function|Promise`; optional) - Text to include in response body. Assumes response Content-Type of `text/plain`.
+- `type` (`String|Function|Promise`; optional) - Override/manual content type for response as a file extension or MIME type.
 
 For dynamic behavior, the noted methods above can also be defined as functions that return response body values.
 For asynchronous behavior, they can be defined as promises that resolve with such values, or a functions that return such promises.

--- a/packages/mockyeah-fetch/src/respond.ts
+++ b/packages/mockyeah-fetch/src/respond.ts
@@ -79,7 +79,7 @@ const respond = async (
 
   body = body || '';
 
-  contentType = type ? mime.getType(type) : contentType;
+  contentType = type ? mime.getType(type) || type : contentType;
 
   const headers: RequestInit['headers'] = resOpts.headers
     ? {


### PR DESCRIPTION
Not sure if this is a bug fix or a new feature, but if we get `type` in response options, we try to map it to a MIME type using `mime`'s `getType`, otherwise we send no type. We can instead fallback to the raw `type` passed to support unknown or custom MIME types.