### PR TITLE
feat(fetch): intercept response

### DIFF
--- a/packages/mockyeah-docs/src/pages/API/Mock-API.md
+++ b/packages/mockyeah-docs/src/pages/API/Mock-API.md
@@ -160,13 +160,14 @@ For dynamic behavior, the noted methods above can also be defined as functions t
 For asynchronous behavior, they can be defined as promises that resolve with such values, or a functions that return such promises.
 
 The functions will receive a `req` argument with these properties:
-  - `url` (`string`)
-  - `path` (`string`) alias of `url`
-  - `method` (`string`) lowercase
-  - `query` (`Record<string, string>`) Query parameters.
-  - `headers` (`Record<string, string>`)
-  - `cookies` (`Record<string, string>`)
-  - `body` (`string` | `Record<string, any>`)
+
+- `url` (`string`)
+- `path` (`string`) alias of `url`
+- `method` (`string`) lowercase
+- `query` (`Record<string, string>`) Query parameters.
+- `headers` (`Record<string, string>`)
+- `cookies` (`Record<string, string>`)
+- `body` (`string` | `Record<string, any>`)
 
 If you wish, mockyeah can also internally fetch and give you the actual response,
 which you can then manipulate or derive a mock response.

--- a/packages/mockyeah-docs/src/pages/API/Mock-API.md
+++ b/packages/mockyeah-docs/src/pages/API/Mock-API.md
@@ -157,9 +157,27 @@ Response options informing mockyeah how to respond to matching requests. Support
 
 For dynamic behavior, the noted methods above can also be defined as functions that return response body values.
 For asynchronous behavior, they can be defined as promises that resolve with such values, or a functions that return such promises.
-The functions will receive the [Express request object](https://expressjs.com/en/api.html#req) as a first and only argument.
 
-Examples:
+The functions will receive a `req` argument with these properties:
+  - `url` (`string`)
+  - `path` (`string`) alias of `url`
+  - `method` (`string`) lowercase
+  - `query` (`Record<string, string>`) Query parameters.
+  - `headers` (`Record<string, string>`)
+  - `cookies` (`Record<string, string>`)
+  - `body` (`string` | `Record<string, any>`)
+
+If you wish, mockyeah can also internally fetch and give you the actual response,
+which you can then manipulate or derive a mock response.
+You can enable this behavior by adding a 2nd `res` argument to your
+response option functions:
+
+- `res` has properties:
+  - `status` (`number`)
+  - `headers` (`Record<string, string>`)
+  - `body` (`string` | `Record<string, any>`)
+
+Examples of dynamic responses:
 
 ```js
 mockyeah.get('/service/exists', { json: req => ({ hello: req.query.name }) });
@@ -173,6 +191,21 @@ mockyeah.get('/service/exists', {
 
 ```js
 mockyeah.get('/service/exists', { json: Promise.resolve({ hello: 'there' }) });
+```
+
+```js
+mockyeah.get('https://httpbin.org/json', {
+  json: (req, res) => ({
+    ...(res && res.body),
+    other: 'whatever'
+  })
+});
+```
+
+```js
+mockyeah.get('https://httpbin.org/html', {
+  text: (req, res) => res.body.replace(/<h1/g, '<h2').toUpperCase()
+});
 ```
 
 **Additional options:**

--- a/packages/mockyeah-fetch/src/handleEmptyBody.ts
+++ b/packages/mockyeah-fetch/src/handleEmptyBody.ts
@@ -1,4 +1,4 @@
-const parseBody = async (res: Response) => {
+const handleEmptyBody = async (res: Response) => {
   const { status } = res;
 
   if (status === 204) return '';
@@ -6,4 +6,4 @@ const parseBody = async (res: Response) => {
   return res.text() || '';
 };
 
-export { parseBody };
+export { handleEmptyBody };

--- a/packages/mockyeah-fetch/src/headersToObject.ts
+++ b/packages/mockyeah-fetch/src/headersToObject.ts
@@ -1,0 +1,26 @@
+import fromPairs from 'lodash/fromPairs';
+
+const headersToObject = (headers?: Headers): Record<string, string> => {
+  if (!headers) return {};
+
+  // @ts-ignore
+  if (headers.entries) {
+    // @ts-ignore
+    const entries = headers.entries();
+    return fromPairs([...entries].map(e => [e[0].toLowerCase(), e[1]]));
+  }
+
+  if (headers.forEach) {
+    const object: Record<string, string> = {};
+
+    headers.forEach((value, name) => {
+      object[name] = value;
+    });
+
+    return object;
+  }
+
+  return {};
+};
+
+export { headersToObject };

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -3,7 +3,6 @@ import { parse } from 'url';
 import qs from 'qs';
 import isPlainObject from 'lodash/isPlainObject';
 import flatten from 'lodash/flatten';
-import fromPairs from 'lodash/fromPairs';
 import cookie from 'cookie';
 import debug from 'debug';
 import matches from 'match-deep';
@@ -11,7 +10,9 @@ import { normalize } from './normalize';
 import { isMockEqual } from './isMockEqual';
 import { respond } from './respond';
 import { Expectation } from './Expectation';
-import { parseBody } from './parseBody';
+import { handleEmptyBody } from './handleEmptyBody';
+import { parseResponseBody } from './parseResponseBody';
+import { headersToObject } from './headersToObject';
 import {
   BootOptions,
   FetchOptions,
@@ -24,7 +25,8 @@ import {
   ResponseOptions,
   ResponseOptionsObject,
   RequestForHandler,
-  Action
+  Action,
+  responseOptionsResponderKeys
 } from './types';
 
 const debugMock = debug('mockyeah:fetch:mock');
@@ -210,16 +212,7 @@ class Mockyeah {
       return this.fallbackFetch(url, init, { noProxy });
     }
 
-    // TODO: Does this handle lowercase `content-type`?
-    const contentType = inHeaders && inHeaders.get('Content-Type');
-    // TODO: More robust content-type parsing.
-    const isBodyJson = contentType && contentType.includes('application/json');
-
-    const inBody =
-      options.body && isBodyJson
-        ? JSON.parse(options.body)
-        : // TODO: Support forms as key/value object (see https://expressjs.com/en/api.html#req.body)
-          options.body;
+    const inBody = inHeaders && parseResponseBody(inHeaders, options.body);
 
     const query = parsed.query ? qs.parse(parsed.query) : undefined;
     const method: Method = options.method ? (options.method.toLowerCase() as Method) : 'get';
@@ -345,7 +338,32 @@ class Mockyeah {
         matchingMock[0].$meta.expectation.request(requestForHandler);
       }
 
-      const { response, json } = await respond(matchingMock, requestForHandler, bootOptions);
+      let realRes;
+      const resOpts = matchingMock[1];
+
+      const intercept = resOpts && responseOptionsResponderKeys.some(option =>
+        // @ts-ignore
+        typeof resOpts[option] === 'function' && resOpts[option].length > 1
+      );
+
+      if (intercept) {
+        const realResponse = await this.fallbackFetch(url, options);
+
+        const body = parseResponseBody(realResponse.headers, await realResponse.text());
+
+        realRes = {
+          status: realResponse.status,
+          body,
+          headers: headersToObject(realResponse.headers)
+        };
+      }
+
+      const { response, json } = await respond(
+        matchingMock,
+        requestForHandler,
+        bootOptions,
+        realRes
+      );
 
       debugHit(`${logPrefix} @mockyeah/fetch matched mock for`, url, {
         request: requestForHandler,
@@ -391,7 +409,7 @@ class Mockyeah {
 
   async fallbackFetch(input: RequestInfo, init?: RequestInit, fetchOptions: FetchOptions = {}) {
     const { noProxy } = fetchOptions;
-    const { responseHeaders } = this.__private.bootOptions;
+    const { responseHeaders, fetch } = this.__private.bootOptions;
 
     const url = typeof input === 'string' ? input : input.url;
 
@@ -410,16 +428,14 @@ class Mockyeah {
 
     let res = await fetch(input, init);
 
-    const body = await parseBody(res);
+    const body = await handleEmptyBody(res);
 
     const { ws, recording } = this.__private;
 
     if (recording) {
       const { status } = res;
 
-      // @ts-ignore
-      const entries = res.headers.entries();
-      const headers = fromPairs([...entries].map(e => [e[0].toLowerCase(), e[1]]));
+      const headers = headersToObject(res.headers);
 
       if (ws) {
         const action: Action = {

--- a/packages/mockyeah-fetch/src/parseResponseBody.ts
+++ b/packages/mockyeah-fetch/src/parseResponseBody.ts
@@ -1,0 +1,13 @@
+const parseResponseBody = (headers: Headers, body?: string | null) => {
+  // TODO: Does this handle lowercase `content-type`?
+  const contentType = headers && headers.get('Content-Type');
+  // TODO: More robust content-type parsing.
+  const isJson = contentType && contentType.includes('application/json');
+
+  return body && isJson
+    ? JSON.parse(body)
+    : // TODO: Support forms as key/value object (see https://expressjs.com/en/api.html#req.body)
+      body;
+};
+
+export { parseResponseBody };

--- a/packages/mockyeah-fetch/src/respond.ts
+++ b/packages/mockyeah-fetch/src/respond.ts
@@ -6,11 +6,16 @@ import {
   ResponderFunction,
   RequestForHandler,
   BootOptions,
-  Json
+  Json,
+  ResponseObject
 } from './types';
 
-const handler = <T>(value: Responder<T>, requestForHandler: RequestForHandler): T | Promise<T> =>
-  typeof value === 'function' ? (value as ResponderFunction<T>)(requestForHandler) : value;
+const handler = <T>(
+  value: Responder<T>,
+  requestForHandler: RequestForHandler,
+  res?: ResponseObject
+): T | Promise<T> =>
+  typeof value === 'function' ? (value as ResponderFunction<T>)(requestForHandler, res) : value;
 
 interface Respond {
   response: Response;
@@ -20,60 +25,52 @@ interface Respond {
 const respond = async (
   matchingMock: MockNormal,
   requestForHandler: RequestForHandler,
-  options: BootOptions
+  bootOptions: BootOptions,
+  res?: ResponseObject
 ): Promise<Respond> => {
-  const { responseHeaders } = options;
+  const { responseHeaders, fixtureResolver, fileResolver } = bootOptions;
 
   const resOpts: ResponseOptionsObject = matchingMock[1] || {};
 
   const status =
-    (resOpts.status && (await handler<number>(resOpts.status, requestForHandler))) || 200;
+    (resOpts.status && (await handler<number>(resOpts.status, requestForHandler, res))) || 200;
 
   let body;
-  const awaitedType = (resOpts.type && (await resOpts.type)) as
-    | string
-    | ((req: RequestForHandler) => string)
-    | undefined;
 
-  let type: string | undefined;
-
-  if (typeof awaitedType === 'function') {
-    type = awaitedType(requestForHandler) as string | undefined;
-  } else {
-    type = awaitedType;
-  }
+  let type: string | undefined =
+    resOpts.type && (await handler<string>(resOpts.type, requestForHandler, res));
 
   let contentType: string | null | undefined;
 
   let json;
 
   if (resOpts.fixture) {
-    if (!options.fixtureResolver) {
+    if (!fixtureResolver) {
       throw new Error('Using `fixture` in mock response options requires a `fixtureResolver`.');
     }
-    const fixture = await handler<string>(resOpts.fixture, requestForHandler);
+    const fixture = await handler<string>(resOpts.fixture, requestForHandler, res);
     type = type || fixture; // TODO: Use base name only to conceal file path?
-    body = fixture ? await options.fixtureResolver(fixture) : undefined;
+    body = fixture ? await fixtureResolver(fixture) : undefined;
   } else if (resOpts.filePath) {
-    if (!options.fileResolver) {
+    if (!fileResolver) {
       throw new Error('Using `filePath` in mock response options requires a `fileResolver`.');
     }
-    const filePath = await handler<string>(resOpts.filePath, requestForHandler);
+    const filePath = await handler<string>(resOpts.filePath, requestForHandler, res);
     type = type || filePath; // TODO: Use base name only to conceal file path?
-    body = filePath ? await options.fileResolver(filePath) : undefined;
+    body = filePath ? await fileResolver(filePath) : undefined;
   } else if (resOpts.json) {
-    json = await handler(resOpts.json, requestForHandler);
+    json = await handler(resOpts.json, requestForHandler, res);
     body = JSON.stringify(json);
     contentType = 'application/json; charset=UTF-8';
   } else if (resOpts.text) {
-    body = await handler(resOpts.text, requestForHandler);
+    body = await handler(resOpts.text, requestForHandler, res);
     contentType = 'text/plain; charset=UTF-8';
   } else if (resOpts.html) {
-    body = await handler(resOpts.html, requestForHandler);
+    body = await handler(resOpts.html, requestForHandler, res);
     contentType = 'text/html; charset=UTF-8';
   } else if (resOpts.raw) {
-    // TODO: This has different semantics that the Express version.
-    body = await handler(resOpts.raw, requestForHandler);
+    // TODO: This has different semantics than the Express version.
+    body = await handler(resOpts.raw, requestForHandler, res);
     contentType = undefined;
   }
 
@@ -83,7 +80,7 @@ const respond = async (
 
   const headers: RequestInit['headers'] = resOpts.headers
     ? {
-        ...(await handler<Record<string, string>>(resOpts.headers, requestForHandler))
+        ...(await handler<Record<string, string>>(resOpts.headers, requestForHandler, res))
       }
     : {};
 
@@ -100,7 +97,7 @@ const respond = async (
     headers
   };
 
-  const latency = resOpts.latency || options.latency;
+  const latency = resOpts.latency || bootOptions.latency;
 
   if (latency) {
     const latencyActual = await handler<number>(latency, requestForHandler);

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -43,11 +43,17 @@ interface RequestForHandler {
   body?: any;
 }
 
+interface ResponseObject {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: any;
+}
+
 type ResponderResult<T> = T | Promise<T>;
 
 type ResponderFunction<T> =
-  | ((arg: RequestForHandler) => T)
-  | ((arg: RequestForHandler) => Promise<T>);
+  | ((req: RequestForHandler, res?: ResponseObject) => T)
+  | ((req: RequestForHandler, res?: ResponseObject) => Promise<T>);
 
 type Responder<T> = ResponderResult<T> | ResponderFunction<T>;
 
@@ -61,21 +67,10 @@ interface ResponseOptionsObject {
   status?: Responder<number>;
   type?: Responder<string>;
   latency?: Responder<number>;
-  headers?: Record<string, string>;
+  headers?: Responder<Record<string, string>>;
 }
 
-const responseOptionsKeys = [
-  'fixture',
-  'filePath',
-  'html',
-  'json',
-  'text',
-  'status',
-  'headers',
-  'raw',
-  'latency',
-  'type'
-];
+const responseOptionsResponderKeys = ['json', 'text', 'html', 'raw', 'filePath', 'fixture', 'status', 'type', 'latency', 'headers']
 
 type ResponseOptions = string | ResponseOptionsObject;
 
@@ -179,6 +174,7 @@ export {
   Responder,
   ResponderFunction,
   ResponderResult,
+  ResponseObject,
   Matcher,
   Match,
   MatchFunction,
@@ -192,10 +188,10 @@ export {
   MockFunction,
   MockReturn,
   RequestForHandler,
-  responseOptionsKeys,
   Expectation,
   VerifyCallback,
   RunHandler,
   RunHandlerOrPromise,
-  Action
+  Action,
+  responseOptionsResponderKeys
 };


### PR DESCRIPTION
Response option functions like  functions like `json`, `text`, `status`, `headers`, etc., can now be defined with a 2nd `res` argument after existing `req` argument. Any such response option will cause Mockyeah to actually make a real fetch call to that URL, and then give your function the response data as `res` (with `status`, `headers`, and `body` fields) which you can then manipulate or derive a mock response.

Fixes #403.

Relates to #441.