### PR TITLE
feat(docs): add alert for mockyeah 0.x docs

### DIFF
--- a/packages/mockyeah-docs/gatsby-browser.js
+++ b/packages/mockyeah-docs/gatsby-browser.js
@@ -4,13 +4,10 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 import React from 'react';
-import { Link } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import 'prismjs/themes/prism.css';
 
-const components = {
-  a: ({ href, ...props }) => <Link to={href} {...props} />
-};
+const components = {};
 
 export const wrapRootElement = ({ element }) => (
   <MDXProvider components={components}>{element}</MDXProvider>

--- a/packages/mockyeah-docs/package-lock.json
+++ b/packages/mockyeah-docs/package-lock.json
@@ -7548,19 +7548,11 @@
 			}
 		},
 		"find-versions": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.1.0.tgz",
-			"integrity": "sha512-NCTfNiVzeE/xL+roNDffGuRbrWI6atI18lTJ22vKp7rs2OhYzMK3W1dIdO2TUndH/QMcacM4d1uWwgcZcHK69Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+			"integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
 			"requires": {
-				"array-uniq": "^2.1.0",
 				"semver-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"array-uniq": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
-					"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ=="
-				}
 			}
 		},
 		"flat": {
@@ -9447,15 +9439,15 @@
 			}
 		},
 		"gatsby-plugin-sharp": {
-			"version": "2.2.25",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.25.tgz",
-			"integrity": "sha512-NBoMWC/AtImBggdzePVH1Iqj6DqG23uhrrcEmCoVq5pJDvuGaq/Wsr9+igQT6rJ8MbfFHNxSyY0JvDREelbc9Q==",
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.3.10.tgz",
+			"integrity": "sha512-uoVLdSnnrnpWxeI+ZNdQ7nuvx60LI8+nqsuUu0KfyAmEhNgcuuExTDYlM4WDn1BCIifCylTwBBTP0xZU4YvPeA==",
 			"requires": {
-				"@babel/runtime": "^7.6.0",
+				"@babel/runtime": "^7.7.6",
 				"async": "^2.6.3",
-				"bluebird": "^3.5.5",
+				"bluebird": "^3.7.2",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.10",
+				"gatsby-core-utils": "^1.0.25",
 				"got": "^8.3.2",
 				"imagemin": "^6.1.0",
 				"imagemin-mozjpeg": "^8.0.0",
@@ -9463,21 +9455,72 @@
 				"imagemin-webp": "^5.1.0",
 				"lodash": "^4.17.15",
 				"mini-svg-data-uri": "^1.1.3",
+				"p-defer": "^3.0.0",
 				"potrace": "^2.1.2",
 				"probe-image-size": "^4.1.1",
 				"progress": "^2.0.3",
 				"semver": "^5.7.1",
-				"sharp": "^0.23.0",
-				"svgo": "^1.3.0",
+				"sharp": "^0.23.4",
+				"svgo": "1.3.2",
 				"uuid": "^3.3.3"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+					"integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
 				"async": {
 					"version": "2.6.3",
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
 					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"requires": {
 						"lodash": "^4.17.14"
+					}
+				},
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+				},
+				"gatsby-core-utils": {
+					"version": "1.0.25",
+					"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.25.tgz",
+					"integrity": "sha512-Pz5xueweH9qv5TIW7wwlTxI/CbyzkiE5xvgLicbHbU+InH+lCNt4VuvGP1gQcIRuHMCIbuVKSiVCC7jnxEbtrA==",
+					"requires": {
+						"ci-info": "2.0.0",
+						"node-object-hash": "^2.0.0"
+					}
+				},
+				"p-defer": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+					"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+				},
+				"sharp": {
+					"version": "0.23.4",
+					"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.4.tgz",
+					"integrity": "sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==",
+					"requires": {
+						"color": "^3.1.2",
+						"detect-libc": "^1.0.3",
+						"nan": "^2.14.0",
+						"npmlog": "^4.1.2",
+						"prebuild-install": "^5.3.3",
+						"semver": "^6.3.0",
+						"simple-get": "^3.1.0",
+						"tar": "^5.0.5",
+						"tunnel-agent": "^0.6.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+						}
 					}
 				}
 			}

--- a/packages/mockyeah-docs/package.json
+++ b/packages/mockyeah-docs/package.json
@@ -26,7 +26,7 @@
     "gatsby-plugin-mdx": "^1.0.43",
     "gatsby-plugin-offline": "3.0.8",
     "gatsby-plugin-react-helmet": "3.1.8",
-    "gatsby-plugin-sharp": "2.2.25",
+    "gatsby-plugin-sharp": "^2.3.10",
     "gatsby-plugin-sitemap": "^2.2.14",
     "gatsby-remark-autolink-headers": "^2.1.11",
     "gatsby-remark-prismjs": "^3.3.28",

--- a/packages/mockyeah-docs/package.json
+++ b/packages/mockyeah-docs/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.4.5",
     "@mdx-js/react": "^1.4.5",
-    "@mockyeah/tools": "^1.0.0-alpha.6",
     "gatsby": "^2.18.11",
     "gatsby-image": "2.2.20",
     "gatsby-plugin-catch-links": "^2.1.10",
@@ -43,6 +42,7 @@
     "remark-react": "^6.0.0"
   },
   "devDependencies": {
+    "@mockyeah/tools": "^1.0.0-alpha.6",
     "gatsby-cli": "^2.8.22",
     "prettier": "1.18.2"
   }

--- a/packages/mockyeah-docs/package.json
+++ b/packages/mockyeah-docs/package.json
@@ -42,8 +42,10 @@
     "remark-react": "^6.0.0"
   },
   "devDependencies": {
-    "@mockyeah/tools": "^1.0.0-alpha.6",
     "gatsby-cli": "^2.8.22",
     "prettier": "1.18.2"
+  },
+  "optionalDependencies": {
+    "@mockyeah/tools": "^1.0.0-alpha.6"
   }
 }

--- a/packages/mockyeah-docs/src/components/Alert.js
+++ b/packages/mockyeah-docs/src/components/Alert.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 const Alert = ({ children }) => {
   return (
-    <div style={{ background: '#fff3cd', color: '#856404', border: '1px solid #ffeeba', padding: 12 }}>
+    <div
+      style={{ background: '#fff3cd', color: '#856404', border: '1px solid #ffeeba', padding: 12 }}
+    >
       {children}
     </div>
-  )
+  );
 };
 
 export { Alert };

--- a/packages/mockyeah-docs/src/components/Alert.js
+++ b/packages/mockyeah-docs/src/components/Alert.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Alert = ({ children }) => {
+  return (
+    <div style={{ background: '#fff3cd', color: '#856404', border: '1px solid #ffeeba', padding: 12 }}>
+      {children}
+    </div>
+  )
+};
+
+export { Alert };

--- a/packages/mockyeah-docs/src/components/header.js
+++ b/packages/mockyeah-docs/src/components/header.js
@@ -1,6 +1,7 @@
 import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Alert } from './Alert';
 import logo from '../images/logo/mockyeah-600.png';
 
 const Header = ({ siteTitle, siteDescription }) => (
@@ -63,6 +64,14 @@ const Header = ({ siteTitle, siteDescription }) => (
         </div>
       </div>
     </div>
+
+    <Alert>
+      <div style={{ textAlign: 'center' }}>
+        <strong>Notice:</strong> These docs are for mockyeah <code>1.x</code> & above. For legacy
+        mockyeah <code>0.x</code>, please see{' '}
+        <a href="https://mockyeah.github.io/mockyeah">mockyeah.github.io/mockyeah</a>.
+      </div>
+    </Alert>
   </header>
 );
 

--- a/packages/mockyeah-docs/src/components/layout.css
+++ b/packages/mockyeah-docs/src/components/layout.css
@@ -597,10 +597,16 @@ code {
   padding: 0;
   padding-top: 0.2em;
   padding-bottom: 0.2em;
+  padding-left: 0.2em;
+  margin-left: 0.2em;
+  margin-right: 0.2em;
 }
 pre code {
   background: none;
   line-height: 1.42;
+  padding-left: 0;
+  margin-left: 0;
+  margin-right: 0;
 }
 code:before,
 code:after,


### PR DESCRIPTION
Adds an alert to the top of the new `1.x` docs site pointing users to the legacy docs for `0.x`.

![Screen Shot 2020-01-05 at 11 43 44 AM](https://user-images.githubusercontent.com/615381/71783738-ba9fb600-2fb0-11ea-9e8d-2376f9521b75.png)
