### PR TITLE
chore(docs): remove CNAME

### DIFF
--- a/packages/mockyeah-docs/CNAME
+++ b/packages/mockyeah-docs/CNAME
@@ -1,1 +1,0 @@
-mockyeah.js.org


### PR DESCRIPTION
We don't need CNAME anymore since we're using Netlify.