### PR TITLE
test(server): fix record nothing test without proxying

### DIFF
--- a/packages/mockyeah/test/integration/RecordNothingTest.js
+++ b/packages/mockyeah/test/integration/RecordNothingTest.js
@@ -45,7 +45,7 @@ describe('Record Nothing Test', function() {
         }
       ],
       () => {
-        proxyReq = supertest(`${proxy.server.rootUrl}/http://mockyeah.js.org`);
+        proxyReq = supertest(`${proxy.server.url}/whatever`);
         done();
       }
     );


### PR DESCRIPTION
Fix the server record nothing test by not using an absolute URL to make the proxy requests since it's failing with the new mockyeah.js.org site with this error:

```
Error: Parse Error: Content-Length can't be present with chunked encoding
      at Socket.socketOnData (_http_client.js:470:22)
      at addChunk (_stream_readable.js:341:12)
      at readableAddChunk (_stream_readable.js:316:11)
      at Socket.Readable.push (_stream_readable.js:250:10)
      at TCP.onStreamRead (internal/stream_base_commons.js:186:23)
```
