### PR TITLE
fix(docs): update mockyeah 0.x docs link

### DIFF
--- a/packages/mockyeah-docs/src/components/header.js
+++ b/packages/mockyeah-docs/src/components/header.js
@@ -69,7 +69,7 @@ const Header = ({ siteTitle, siteDescription }) => (
       <div style={{ textAlign: 'center' }}>
         <strong>Notice:</strong> These docs are for mockyeah <code>1.x</code> & above. For legacy
         mockyeah <code>0.x</code>, please see{' '}
-        <a href="https://mockyeah.github.io/mockyeah">mockyeah.github.io/mockyeah</a>.
+        <a href="https://mockyeah.github.io/mockyeah/">https://mockyeah.github.io/mockyeah/</a>.
       </div>
     </Alert>
   </header>


### PR DESCRIPTION
Update mockyeah `0.x` docs link to use a trailing slash since for whatever reason with that it isn't redirecting to `mockyeah.js.org` on Netlify like it is without the trailing slash. Maybe this is just a DNS TTL thing but for now this should work.