### PR TITLE
fix(fetch): mock suite resolver not assume default

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -249,8 +249,7 @@ class Mockyeah {
       const mockSuiteLoadeds = await Promise.all(mockSuiteLoads);
       mockSuiteLoadeds.forEach((mockSuiteLoaded, index) => {
         const name = mockSuiteNames[index];
-        const { default: mockSuite } = mockSuiteLoaded;
-        mockSuite.forEach(mock => {
+        (mockSuiteLoaded.default || mockSuiteLoaded).forEach(mock => {
           const [match, response] = mock;
           const newMatch = (isPlainObject(match)
             ? { ...(match as MatchObject) }

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -143,7 +143,7 @@ type Mock = [Match, ResponseOptions];
 
 type MockSuite = Mock[];
 
-type MockSuiteResolver = (suiteName: string) => Promise<{ default: MockSuite }>;
+type MockSuiteResolver = (suiteName: string) => Promise<MockSuite & { default?: MockSuite }>;
 
 type MockNormal = [MatchNormal, ResponseOptionsObject];
 


### PR DESCRIPTION
Don't assume a `default` export in mock suites loaded, but check for it first for compatibility with both TS/ES Modules transpiled code and also with traditional CommonJS/Node `module.exports` code.