### PR TITLE
feat(fetch): normalize adds meta original serialized

### DIFF
--- a/packages/mockyeah-fetch/src/__tests__/normalize.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/normalize.test.ts
@@ -61,12 +61,60 @@ describe('normalize', () => {
       }
     });
   });
+
+  test('original normal with url as top-level regex', () => {
+    expect(normalize(/ok/)).toMatchObject({
+      $meta: {
+        originalNormal: {
+          url: /ok/
+        }
+      }
+    });
+  });
+
+  test('original normal with url as regex', () => {
+    expect(
+      normalize({
+        url: /ok/
+      })
+    ).toMatchObject({
+      $meta: {
+        originalNormal: {
+          url: /ok/
+        }
+      }
+    });
+  });
+
+  test('original serialized with url as top-level regex', () => {
+    expect(normalize(/ok/)).toMatchObject({
+      $meta: {
+        originalSerialized: {
+          url: { $regex: { source: 'ok' } }
+        }
+      }
+    });
+  });
+
+  test('original serialized with url as regex', () => {
+    expect(
+      normalize({
+        url: /ok/
+      })
+    ).toMatchObject({
+      $meta: {
+        originalSerialized: {
+          url: { $regex: { source: 'ok' } }
+        }
+      }
+    });
+  });
 });
 
 describe('stripQuery', () => {
   test('strips', () => {
     expect(stripQuery('https://ok.com:123/yes?hello=there&sir')).toMatchObject({
       url: 'https://ok.com:123/yes'
-    })
+    });
   });
 });

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -70,7 +70,18 @@ interface ResponseOptionsObject {
   headers?: Responder<Record<string, string>>;
 }
 
-const responseOptionsResponderKeys = ['json', 'text', 'html', 'raw', 'filePath', 'fixture', 'status', 'type', 'latency', 'headers']
+const responseOptionsResponderKeys = [
+  'json',
+  'text',
+  'html',
+  'raw',
+  'filePath',
+  'fixture',
+  'status',
+  'type',
+  'latency',
+  'headers'
+];
 
 type ResponseOptions = string | ResponseOptionsObject;
 
@@ -111,6 +122,7 @@ interface MatchMeta {
   matchKeys?: pathToRegexp.Key[];
   original?: Match;
   originalNormal?: MatchObject;
+  originalSerialized?: MatchObject; // technically we could replace regex types here
   expectation?: Expectation;
 }
 


### PR DESCRIPTION
Updates `@mockyeah/fetch` `normalize` method to include a serialized version of the normalized original match object. This improves the ability to serialize mocks over JSON. For now we only serialize regular expressions, since functions can't really be easily serialized (at least not ones which might access higher scoped variables - perhaps in future we could try to detect those that only access internal scope and serialize those somehow - maybe with something like [`serialize-javascript`](https://www.npmjs.com/package/serialize-javascript)).