### PR TITLE
chore(fetch-demo): optional tools dep for netlify

### DIFF
--- a/packages/mockyeah-fetch-demo/package.json
+++ b/packages/mockyeah-fetch-demo/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-typescript": "^7.7.4",
     "@babel/register": "^7.4.4",
-    "@mockyeah/tools": "^1.0.0-alpha.6",
     "babel-loader": "^8.0.5",
     "html-webpack-plugin": "^3.2.0",
     "source-map-loader": "^0.2.4",
@@ -31,5 +30,8 @@
     "@babel/runtime": "^7.7.4",
     "@mockyeah/fetch": "^1.0.0-alpha.6",
     "core-js-compat": "^3.4.7"
+  },
+  "optionalDependencies": {
+    "@mockyeah/tools": "^1.0.0-alpha.6"
   }
 }


### PR DESCRIPTION
Making `@mockyeah/tools` an optional dependency for `@mockyeah/fetch-demo` so it can skip installing that private package on Netlify builds.