### PR TITLE
docs: add README for @mockyeah/fetch-demo

### DIFF
--- a/packages/mockyeah-fetch-demo/README.md
+++ b/packages/mockyeah-fetch-demo/README.md
@@ -1,0 +1,16 @@
+# @mockyeah/fetch-demo
+
+https://mockyeah-fetch-demo.netlify.com/
+
+Demoing `@mockyeah/fetch` utility for [mockyeah](https://github.com/mockyeah/mockyeah),
+a powerful service mocking, recording, and playback utility.
+
+<img src="https://raw.githubusercontent.com/mockyeah/mockyeah/master/packages/mockyeah-docs/src/images/logo/mockyeah-600.png" height="200" />
+
+[![npm](https://img.shields.io/npm/v/@mockyeah/fetch.svg)](https://www.npmjs.com/package/@mockyeah/fetch)
+
+More at **https://mockyeah.js.org/Integration.html**.
+
+## License
+
+@mockyeah/fetch-demo is released under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
`@mockyeah/fetch-demo` was missing a README - adding one with a link to the its Netlify site. https://mockyeah-fetch-demo.netlify.com/