### PR TITLE
build: only ts files for web ext & fetch demo

### DIFF
--- a/packages/mockyeah-fetch-demo/webpack.config.babel.js
+++ b/packages/mockyeah-fetch-demo/webpack.config.babel.js
@@ -10,7 +10,7 @@ export default (env = {}) => ({
   module: {
     rules: [
       {
-        test: /\.[jt]s$/,
+        test: /\.ts$/,
         exclude: /node_modules/,
         use: 'babel-loader'
       },

--- a/packages/mockyeah-web-extension/package.json
+++ b/packages/mockyeah-web-extension/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "mockyeah web extension",
   "scripts": {
-    "build": "webpack",
-    "dev": "NODE_ENV=development webpack -w",
+    "build": "webpack --config webpack.config.ts",
+    "dev": "NODE_ENV=development webpack --config webpack.config.ts -w",
     "build:prod": "NODE_ENV=production webpack",
     "lint": "eslint --max-warnings 0 src/**/*.ts"
   },

--- a/packages/mockyeah-web-extension/webpack.config.ts
+++ b/packages/mockyeah-web-extension/webpack.config.ts
@@ -41,7 +41,7 @@ const defaults: (env: Args, argv: Args) => Configuration = (
     module: {
       rules: [
         {
-          test: /\.(j|t)sx?$/,
+          test: /\.tsx?$/,
           exclude: /node_modules/,
           use: [
             {


### PR DESCRIPTION
So `.js` files are getting compiled alongside `.ts` files during local development which causes Webpack to pick up the wrong files.