### PR TITLE
docs(webext): crx raw link

### DIFF
--- a/packages/mockyeah-web-extension/README.md
+++ b/packages/mockyeah-web-extension/README.md
@@ -14,7 +14,7 @@
 
 ### Pre-packaged
 
-1. Download [the `.crx` file](mockyeah.crx).
+1. Download [the `.crx` file](mockyeah.crx?raw=true).
 
 2. In Chrome, go to `Settings` (the `⋮` icon in top-right corner) > `More Tools` > `Extensions`
 


### PR DESCRIPTION
The README link to the `.crx` file should've had `?raw=true` to trigger a download.