### PR TITLE
feat(fetch): latency function gets response

### DIFF
--- a/packages/mockyeah-fetch/src/respond.ts
+++ b/packages/mockyeah-fetch/src/respond.ts
@@ -13,7 +13,7 @@ import {
 const handler = <T>(
   value: Responder<T>,
   requestForHandler: RequestForHandler,
-  res: ResponseObject
+  res?: ResponseObject
 ): T | Promise<T> =>
   typeof value === 'function' ? (value as ResponderFunction<T>)(requestForHandler, res) : value;
 

--- a/packages/mockyeah-fetch/src/respond.ts
+++ b/packages/mockyeah-fetch/src/respond.ts
@@ -13,7 +13,7 @@ import {
 const handler = <T>(
   value: Responder<T>,
   requestForHandler: RequestForHandler,
-  res?: ResponseObject
+  res: ResponseObject
 ): T | Promise<T> =>
   typeof value === 'function' ? (value as ResponderFunction<T>)(requestForHandler, res) : value;
 
@@ -100,7 +100,7 @@ const respond = async (
   const latency = resOpts.latency || bootOptions.latency;
 
   if (latency) {
-    const latencyActual = await handler<number>(latency, requestForHandler);
+    const latencyActual = await handler<number>(latency, requestForHandler, res);
     await new Promise(resolve => setTimeout(resolve, latencyActual));
   }
 

--- a/packages/mockyeah-web-extension/README.md
+++ b/packages/mockyeah-web-extension/README.md
@@ -11,7 +11,7 @@ You can edit mocks you've created. Chrome will save them so they're still there 
 The extension interacts with `@mockyeah/fetch` on your web page, so it looks for a `window.__MOCKYEAH__` variable assigned to a `mockyeah` instance you create in your app source code (perhaps only development builds) with the `devTools` option enabled, as follows:
 
 ```js
-import Mockyeah from '@mockyeah/fetch';
+import Mockyeah from "@mockyeah/fetch";
 
 const mockyeah = new Mockyeah({
   devTools: true


### PR DESCRIPTION
The latency function should receive the `res` argument as well. Latency is added to the top of the actual underlying request (for now). Relates to #424 