### PR TITLE
fix(cli): mock all method

### DIFF
--- a/packages/mockyeah-docs/src/pages/API/Mock-API.md
+++ b/packages/mockyeah-docs/src/pages/API/Mock-API.md
@@ -148,7 +148,9 @@ Response options informing mockyeah how to respond to matching requests.
 If you pass just a string as response options, that's equivalent to passing just:
 
 ```js
-{ text: 'your string' }
+{
+  text: 'your string';
+}
 ```
 
 See below for explanation of the `Responder` type.

--- a/packages/mockyeah-fetch/src/Expectation.ts
+++ b/packages/mockyeah-fetch/src/Expectation.ts
@@ -37,7 +37,7 @@ class Expectation {
     const originalNormal =
       match.$meta && match.$meta.originalNormal ? match.$meta.originalNormal : match;
 
-    this.prefix = `[${originalNormal.method || 'get'}] ${originalNormal.path ||
+    this.prefix = `[${originalNormal.method || 'all'}] ${originalNormal.path ||
       originalNormal.url} --`;
 
     this.called = 0;

--- a/packages/mockyeah-fetch/src/normalize.ts
+++ b/packages/mockyeah-fetch/src/normalize.ts
@@ -100,9 +100,7 @@ const normalize = (match: Match, incoming?: boolean): MatchNormal => {
         return acc;
       }, {} as Record<string, MatchString>);
 
-  if (!match.method) {
-    match.method = 'get';
-  } else if (match.method === 'all' || match.method === 'ALL' || match.method === '*') {
+  if (!match.method || match.method === 'all' || match.method === 'ALL' || match.method === '*') {
     delete match.method;
   } else if (typeof match.method === 'string') {
     match.method = match.method.toLowerCase() as Method;

--- a/packages/mockyeah/app/makeAPI/makePlay.js
+++ b/packages/mockyeah/app/makeAPI/makePlay.js
@@ -25,7 +25,7 @@ const makePlay = app => {
 
       suite.forEach((c, i) => {
         // TODO: Handle `suiteName` and `suiteIndex` in `@mockyeah/fetch` on mount for logging.
-        return app.locals.mockyeahFetch.all(...c, {
+        return app.locals.mockyeahFetch.mock(...c, {
           suiteName: name,
           suiteIndex: i
         });


### PR DESCRIPTION
Mocks for all methods or unspecified methods were defaulting to `get` and missing.