### PR TITLE
fix(fetch): request for handler gets port & host

### DIFF
--- a/packages/mockyeah-fetch/src/__tests__/index.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/index.test.ts
@@ -249,9 +249,12 @@ describe('@mockyeah/fetch', () => {
   test('should work url function match', async () => {
     mockyeah = new Mockyeah(options);
 
-    mockyeah.mock({
-      url: value => value === 'https://example.local:3333/v1/ok'
-    }, { json: { a: 1 } });
+    mockyeah.mock(
+      {
+        url: value => value === 'https://example.local:3333/v1/ok'
+      },
+      { json: { a: 1 } }
+    );
 
     const response = await mockyeah.fetch('https://example.local:3333/v1/ok');
     const data = await response.json();

--- a/packages/mockyeah-fetch/src/__tests__/index.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/index.test.ts
@@ -246,6 +246,22 @@ describe('@mockyeah/fetch', () => {
     mockyeah.reset();
   });
 
+  test('should work url function match', async () => {
+    mockyeah = new Mockyeah(options);
+
+    mockyeah.mock({
+      url: value => value === 'https://example.local:3333/v1/ok'
+    }, { json: { a: 1 } });
+
+    const response = await mockyeah.fetch('https://example.local:3333/v1/ok');
+    const data = await response.json();
+
+    expect(response.headers.get('content-type')).toMatch('application/json');
+    expect(data).toEqual({ a: 1 });
+
+    mockyeah.reset();
+  });
+
   test('should work with post method, query and text', async () => {
     mockyeah = new Mockyeah(options);
 

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -351,7 +351,7 @@ class Mockyeah {
         });
       });
 
-    const pathname = `${`${parsed.protocol}//` || ''}${parsed.host || ''}${parsed.pathname || '/'}`;
+    const pathname = `${parsed.protocol ? `${parsed.protocol}//` : ''}${parsed.host || ''}${parsed.pathname || '/'}`;
 
     const requestForHandler: RequestForHandler = {
       url: pathname,

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -351,7 +351,8 @@ class Mockyeah {
         });
       });
 
-    const pathname = `${parsed.protocol ? `${parsed.protocol}//` : ''}${parsed.host || ''}${parsed.pathname || '/'}`;
+    const pathname = `${parsed.protocol ? `${parsed.protocol}//` : ''}${parsed.host ||
+      ''}${parsed.pathname || '/'}`;
 
     const requestForHandler: RequestForHandler = {
       url: pathname,

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -351,7 +351,7 @@ class Mockyeah {
         });
       });
 
-    const pathname = parsed.pathname || '/';
+    const pathname = `${`${parsed.protocol}//` || ''}${parsed.host || ''}${parsed.pathname || '/'}`;
 
     const requestForHandler: RequestForHandler = {
       url: pathname,


### PR DESCRIPTION
Looks like in the request handlers we weren't including optional port and host.