### PR TITLE
feat: extended form data matching

### DIFF
--- a/packages/mockyeah-fetch/src/__tests__/index.test.ts
+++ b/packages/mockyeah-fetch/src/__tests__/index.test.ts
@@ -277,6 +277,37 @@ describe('@mockyeah/fetch', () => {
     expect(data).toEqual('hello');
   });
 
+  test('should work with post form', async () => {
+    mockyeah = new Mockyeah(options);
+
+    mockyeah.mock(
+      {
+        method: 'POST',
+        url: 'https://example.local',
+        query: {
+          ok: /yes/
+        },
+        body: {
+          sure: (v: string): boolean => v === 'thing'
+        }
+      },
+      { text: 'hello' }
+    );
+
+    const response = await mockyeah.fetch('https://example.local?ok=yes&and=more', {
+      method: 'post',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: 'sure=thing'
+    });
+    const data = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toMatch('text/plain');
+    expect(data).toEqual('hello');
+  });
+
   test('should work with dynamic response', async () => {
     mockyeah = new Mockyeah(options);
 

--- a/packages/mockyeah-fetch/src/parseResponseBody.ts
+++ b/packages/mockyeah-fetch/src/parseResponseBody.ts
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import qs from 'qs';
 
 const parseResponseBody = (headers: Headers, body?: string | null) => {
   // TODO: Does this handle lowercase `content-type`?
@@ -13,7 +13,7 @@ const parseResponseBody = (headers: Headers, body?: string | null) => {
     }
 
     if (isForm) {
-      return querystring.parse(body);
+      return qs.parse(body);
     }
   }
 

--- a/packages/mockyeah-fetch/src/parseResponseBody.ts
+++ b/packages/mockyeah-fetch/src/parseResponseBody.ts
@@ -1,13 +1,23 @@
+import querystring from 'querystring';
+
 const parseResponseBody = (headers: Headers, body?: string | null) => {
   // TODO: Does this handle lowercase `content-type`?
   const contentType = headers && headers.get('Content-Type');
   // TODO: More robust content-type parsing.
-  const isJson = contentType && contentType.includes('application/json');
+  const isJson = contentType?.includes('application/json');
+  const isForm = contentType?.includes('application/x-www-form-urlencoded');
 
-  return body && isJson
-    ? JSON.parse(body)
-    : // TODO: Support forms as key/value object (see https://expressjs.com/en/api.html#req.body)
-      body;
+  if (body) {
+    if (isJson) {
+      return JSON.parse(body);
+    }
+
+    if (isForm) {
+      return querystring.parse(body);
+    }
+  }
+
+  return body;
 };
 
 export { parseResponseBody };

--- a/packages/mockyeah/app/index.js
+++ b/packages/mockyeah/app/index.js
@@ -62,8 +62,7 @@ module.exports = function App(config) {
 
   app.use(bodyParser.json({ verify: rawBodySaver }));
   app.use(bodyParser.text({ verify: rawBodySaver }));
-  // TODO: Consider `extended: true`.
-  app.use(bodyParser.urlencoded({ verify: rawBodySaver, extended: false }));
+  app.use(bodyParser.urlencoded({ verify: rawBodySaver, extended: true }));
   app.use(bodyParser.raw({ verify: rawBodySaver, type: '*/*' }));
 
   app.locals.proxying = app.config.proxy;


### PR DESCRIPTION
Use `body-parser`'s `extended: true` mode and switch to `qs` from `querystring` for form data matching.