### PR TITLE
build(fetch-demo): resolve packages and build:ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:watch": "lerna run lint:watch",
     "pretty": "prettier --write '**'",
     "pretty:check": "prettier --check '**'",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "[ -z \"$NETLIFY\" ] && lerna bootstrap",
     "postversion": "prettier --write lerna.json"
   },
   "devDependencies": {

--- a/packages/mockyeah-fetch-demo/package.json
+++ b/packages/mockyeah-fetch-demo/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "webpack",
+    "build:ci": "webpack",
     "start": "webpack-dev-server --env.dev"
   },
   "repository": "git@github.com:mockyeah/mockyeah.git",

--- a/packages/mockyeah-fetch-demo/webpack.config.babel.js
+++ b/packages/mockyeah-fetch-demo/webpack.config.babel.js
@@ -5,7 +5,10 @@ export default (env = {}) => ({
   devtool: env.dev ? 'source-map' : undefined,
   entry: './src/index.ts',
   resolve: {
-    extensions: ['.ts', '.js', '.json']
+    extensions: ['.ts', '.js', '.json'],
+    // The '..' supports resolving packages for monorepo build on netlify
+    //  which doesn't seem to allow `lerna link`'s writes to `node_modules`.
+    modules: ['node_modules', '..']
   },
   module: {
     rules: [


### PR DESCRIPTION
For `@mockyeah/fetch-demo`, I'm adding webpack resolve path `'..'` so it can find packages for monorepo build on Netlify which doesn't seem to allow `lerna link`'s writes to `node_modules`.

Also adding `build:ci` script to `@mockyeah/fetch-demo` so Netlify build command doesn't have to individually build `match-deep` and `@mockyeah/fetch` and this, but just one `build:ci` command.

Also scoping the top-level `postinstall` run of `lerna bootstrap` to not run on Netlify.