### PR TITLE
chore: optional deps on CI

### DIFF
--- a/optionalDeps.js
+++ b/optionalDeps.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+const packages = fs.readdirSync('./packages').filter(n => !n.startsWith('.'))
+
+for (const package of packages) {
+  const pkgPath = `./packages/${package}/package.json`;
+  const pkg = require(pkgPath);
+
+  const optDeps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+    ...pkg.optionalDependencies
+  }
+
+
+  delete pkg.dependencies;
+  delete pkg.devDependencies;
+  pkg.optionalDependencies = optDeps;
+
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+}
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "lint:watch": "lerna run lint:watch",
     "pretty": "prettier --write '**'",
     "pretty:check": "prettier --check '**'",
-    "postinstall": "[ ! -z \"$NETLIFY\" ] || lerna bootstrap",
     "postversion": "prettier --write lerna.json"
   },
   "devDependencies": {


### PR DESCRIPTION
Netlify CI for `@mockyeah/fetch-demo` is failing due to `lerna bootstrap` not being able to write to the cached `node_modules`. We'll try `lerna exec -- npm i` each package individually to prevent it from trying to touch the top-level `node_modules`, but we need to make the monorepo packages into `optionalDependencies` so it doesn't fail when trying to install those from npm. This adds a script that makes all deps optional to test it out.