### PR TITLE
chore(workflows): require automerge label

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -22,7 +22,7 @@ jobs:
         uses: "pascalgn/automerge-action@v0.7.2"
         env:
           GITHUB_TOKEN: "${{ secrets.MOCKYEAH_JS_GITHUB_TOKEN }}"
-          MERGE_LABELS: "!work in progress"
+          MERGE_LABELS: "automerge"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           MERGE_FORKS: "false"


### PR DESCRIPTION
It seems that the `!work in progress` may not be working, so switching automerge to opt-in.