### PR TITLE
feat: match log function as string

### DIFF
--- a/packages/match-deep/src/index.ts
+++ b/packages/match-deep/src/index.ts
@@ -80,7 +80,7 @@ const makeMatcher = (options = DEFAULT_MATCH_OPTIONS) => {
           errors.push({
             message: `Value \`${stringify(value)}\` does not pass function${
               source.name ? ` \`${source.name}\`` : ''
-            }${typeof source.toStringForMatchDeep === 'function' ? ` (${source.toStringForMatchDeep()})` : ''}`,
+            }${typeof source.toStringForMatchDeep === 'function' ? ` (\`${source.toStringForMatchDeep()}\`)` : ''}`,
             keyPath
           });
       } catch (error) {

--- a/packages/match-deep/src/index.ts
+++ b/packages/match-deep/src/index.ts
@@ -80,7 +80,11 @@ const makeMatcher = (options = DEFAULT_MATCH_OPTIONS) => {
           errors.push({
             message: `Value \`${stringify(value)}\` does not pass function${
               source.name ? ` \`${source.name}\`` : ''
-            }${typeof source.toStringForMatchDeep === 'function' ? ` (\`${source.toStringForMatchDeep()}\`)` : ''}`,
+            }${
+              typeof source.toStringForMatchDeep === 'function'
+                ? ` (\`${source.toStringForMatchDeep()}\`)`
+                : ''
+            }`,
             keyPath
           });
       } catch (error) {

--- a/packages/match-deep/src/index.ts
+++ b/packages/match-deep/src/index.ts
@@ -80,7 +80,7 @@ const makeMatcher = (options = DEFAULT_MATCH_OPTIONS) => {
           errors.push({
             message: `Value \`${stringify(value)}\` does not pass function${
               source.name ? ` \`${source.name}\`` : ''
-            }`,
+            }${typeof source.toStringForMatchDeep === 'function' ? ` (${source.toStringForMatchDeep()})` : ''}`,
             keyPath
           });
       } catch (error) {

--- a/packages/mockyeah-fetch/src/normalize.ts
+++ b/packages/mockyeah-fetch/src/normalize.ts
@@ -162,7 +162,7 @@ const normalize = (_match: Match, incoming?: boolean): MatchNormal => {
       $meta.regex = regex;
       $meta.matchKeys = matchKeys;
       $meta.fn = match.url.toString();
-      match.url.toStringForMatchDeep = () => url?.toString();
+      match.url.toStringForMatchDeep = () => `"${url?.toString()}"`;
     }
   } else if (isRegExp(match.url)) {
     if (!incoming) {

--- a/packages/mockyeah-fetch/src/normalize.ts
+++ b/packages/mockyeah-fetch/src/normalize.ts
@@ -75,20 +75,22 @@ const makeRequestUrl = (url: string) => {
     : url;
 };
 
-const normalize = (match: Match, incoming?: boolean): MatchNormal => {
-  if (typeof match === 'function') return match;
+const normalize = (_match: Match, incoming?: boolean): MatchNormal => {
+  if (typeof _match === 'function') return _match;
 
-  const originalMatch = isPlainObject(match) ? { ...(match as MatchObject) } : match;
+  const originalMatch = isPlainObject(_match) ? { ...(_match as MatchObject) } : _match;
 
-  if (!isPlainObject(match)) {
+  let match: MatchObject;
+
+  if (!isPlainObject(_match)) {
     match = {
-      url: match
+      url: _match
     } as MatchObject;
   } else {
     // shallow copy
     match = {
       // @ts-ignore
-      ...match
+      ..._match
     } as MatchObject;
   }
 
@@ -149,6 +151,8 @@ const normalize = (match: Match, incoming?: boolean): MatchNormal => {
   $meta.originalNormal = originalNormal;
   $meta.originalSerialized = serializeObject(originalNormal);
 
+  const { url } = match;
+
   if (typeof match.url === 'string') {
     if (!incoming) {
       const matchKeys: pathToRegexp.Key[] = [];
@@ -158,6 +162,7 @@ const normalize = (match: Match, incoming?: boolean): MatchNormal => {
       $meta.regex = regex;
       $meta.matchKeys = matchKeys;
       $meta.fn = match.url.toString();
+      match.url.toStringForMatchDeep = () => url?.toString();
     }
   } else if (isRegExp(match.url)) {
     if (!incoming) {
@@ -166,6 +171,7 @@ const normalize = (match: Match, incoming?: boolean): MatchNormal => {
         regex.test(decodeProtocolAndPort(u)) || regex.test(decodeProtocolAndPort(`/${u}`));
       $meta.regex = regex;
       $meta.fn = match.url.toString();
+      match.url.toStringForMatchDeep = () => url?.toString();
     }
   } else if (typeof match.url === 'function') {
     const fn = match.url;

--- a/packages/mockyeah-fetch/src/types.ts
+++ b/packages/mockyeah-fetch/src/types.ts
@@ -130,7 +130,7 @@ interface MatchMeta {
 }
 
 interface MatchObject {
-  url?: MatchString<string>;
+  url?: MatchString<string> & { toStringForMatchDeep?: () => string | undefined };
   path?: MatchString<string>;
   method?: MatchString<MethodOrAll>;
   query?: Matcher<Record<string, MatchString>>;

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -126,7 +126,7 @@ describe('Route expectation', () => {
         cb => request.get('/foo?some=nope').end(cb),
         cb => {
           expect(expectation.verify).to.throw(
-            'Expect object did not match: Expected `"value"` and value `"nope"` not equal for "query.some". Value `"/foo"` does not pass function for "url"'
+            'Expect object did not match: Expected `"value"` and value `"nope"` not equal for "query.some". Value `"/foo"` does not pass function (/faoo) for "url"'
           );
           cb();
         }

--- a/packages/mockyeah/test/integration/RouteExpectationTest.js
+++ b/packages/mockyeah/test/integration/RouteExpectationTest.js
@@ -126,7 +126,29 @@ describe('Route expectation', () => {
         cb => request.get('/foo?some=nope').end(cb),
         cb => {
           expect(expectation.verify).to.throw(
-            'Expect object did not match: Expected `"value"` and value `"nope"` not equal for "query.some". Value `"/foo"` does not pass function (/faoo) for "url"'
+            'Expect object did not match: Expected `"value"` and value `"nope"` not equal for "query.some". Value `"/foo"` does not pass function (`"/faoo"`) for "url"'
+          );
+          cb();
+        }
+      ],
+      done
+    );
+  });
+
+  it('should fail for expect with auto-mount not matching with regex', done => {
+    const expectation = mockyeah.expect({
+      path: /faoo/,
+      query: {
+        some: 'value'
+      }
+    });
+
+    async.series(
+      [
+        cb => request.get('/foo?some=nope').end(cb),
+        cb => {
+          expect(expectation.verify).to.throw(
+            'Expect object did not match: Expected `"value"` and value `"nope"` not equal for "query.some". Value `"/foo"` does not pass function (`/faoo/`) for "url"'
           );
           cb();
         }


### PR DESCRIPTION
Now we'll provide a stringified version of match functions for use in logging of match failures for the `url` if it was originally derived from a string or regex.