### PR TITLE
fix(fetch): publish workbox script

### DIFF
--- a/packages/mockyeah-fetch/webpack.config.babel.js
+++ b/packages/mockyeah-fetch/webpack.config.babel.js
@@ -48,5 +48,12 @@ export default [
     output: {
       filename: 'serviceWorker.js'
     }
+  }),
+  env => ({
+    ...common(env),
+    entry: './src/workbox.ts',
+    output: {
+      filename: 'workbox.js'
+    }
   })
 ];


### PR DESCRIPTION
Should've published the workbox script for direct consumption by custom service workers as needed per recent docs additions.