### PR TITLE
refactor(fetch): no async in workbox

### DIFF
--- a/packages/mockyeah-fetch/src/workbox.ts
+++ b/packages/mockyeah-fetch/src/workbox.ts
@@ -85,7 +85,7 @@ const handlerCb = ({ event }): Response | Promise<Response> => {
 };
 
 // eslint-disable-next-line no-restricted-globals
-self.addEventListener('message', async event => {
+self.addEventListener('message', event => {
   if (event.data && event.data.type === 'mockyeahRequest') {
     const { data: { payload: { requestId, request, response } } = {}, source: client } = event;
 


### PR DESCRIPTION
Removing the useless `async` function in the `workbox` script since that causes it to get the regenerator runtime in its output.