### PR TITLE
fix(fetch): publish workbox as library

### DIFF
--- a/packages/mockyeah-fetch/webpack.config.babel.js
+++ b/packages/mockyeah-fetch/webpack.config.babel.js
@@ -53,7 +53,8 @@ export default [
     ...common(env),
     entry: './src/workbox.ts',
     output: {
-      filename: 'workbox.js'
+      filename: 'workbox.js',
+      libraryTarget: 'commonjs2'
     }
   })
 ];


### PR DESCRIPTION
Need to publish `workbox` script as a library so it exposes its exports.