### PR TITLE
fix(cli): no call boot in root bin

### DIFF
--- a/packages/mockyeah-cli/bin/mockyeah.js
+++ b/packages/mockyeah-cli/bin/mockyeah.js
@@ -7,19 +7,16 @@
  */
 
 const program = require('commander');
-const boot = require('../lib/boot');
 const version = require('../version');
 
-boot(() => {
-  program
-    .name('mockyeah')
-    .version(version)
-    .command('list', 'list suites')
-    .alias('ls')
-    .command('play [suiteNames]', 'play suite(s)')
-    .command('playAll', 'play all suites')
-    .alias('play-all')
-    .command('record [suiteName]', 'record suite')
-    .command('start', 'start server')
-    .parse(process.argv);
-});
+program
+  .name('mockyeah')
+  .version(version)
+  .command('list', 'list suites')
+  .alias('ls')
+  .command('play [suiteNames]', 'play suite(s)')
+  .command('playAll', 'play all suites')
+  .alias('play-all')
+  .command('record [suiteName]', 'record suite')
+  .command('start', 'start server')
+  .parse(process.argv);


### PR DESCRIPTION
Don't call `boot` in the root `bin` script since it's called by each command file individually as well.