### PR TITLE
fix(cli): default debug

### DIFF
--- a/packages/mockyeah-cli/lib/boot.js
+++ b/packages/mockyeah-cli/lib/boot.js
@@ -8,6 +8,8 @@ const chalk = require('chalk');
 const readPkgUp = require('read-pkg-up');
 const checkVersionMatch = require('./checkVersionMatch');
 
+process.env.DEBUG = process.env.DEBUG || 'mockyeah:*';
+
 const liftoff = new Liftoff({
   name: 'mockyeah',
   moduleName: '@mockyeah/server',


### PR DESCRIPTION
Restore the default debug logs for the mockyeah CLI.