### PR TITLE
chore: package and docs updates

### DIFF
--- a/packages/match-deep/package.json
+++ b/packages/match-deep/package.json
@@ -13,7 +13,12 @@
     "test": "npm run type-check && npm run lint && npm run test:unit",
     "test:unit": "jest"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/match-deep"
+  },
+  "homepage": "https://github.com/mockyeah/mockyeah/tree/master/packages/match-deep",
   "license": "MIT",
   "engines": {
     "node": ">=6.0.0"

--- a/packages/mockyeah-cli/README.md
+++ b/packages/mockyeah-cli/README.md
@@ -7,7 +7,7 @@ a powerful service mocking, recording, and playback utility.
 
 [![npm](https://img.shields.io/npm/v/@mockyeah/cli.svg)](https://www.npmjs.com/package/@mockyeah/cli)
 
-More at **https://mockyeah.js.org/CLI/CLI.html**.
+More at https://mockyeah.js.org/Packages/mockyeah-cli.
 
 ## Options
 

--- a/packages/mockyeah-cli/package.json
+++ b/packages/mockyeah-cli/package.json
@@ -11,7 +11,12 @@
     "test": "npm run lint && jest",
     "lint": "eslint --max-warnings 0 *.js ./bin ./lib"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/mockyeah-cli"
+  },
+  "homepage": "https://mockyeah.js.org/Packages/mockyeah-cli",
   "author": "Ryan Ricard",
   "license": "MIT",
   "publishConfig": {

--- a/packages/mockyeah-docs/src/pages/Compare/index.mdx
+++ b/packages/mockyeah-docs/src/pages/Compare/index.mdx
@@ -5,6 +5,19 @@ title: Compare
 # Compare
 
 There are several tools that share some goals and use cases with `mockyeah`.
+
+You might be familiar with `nock` - it works great for mocking in
+server-side or other Node apps, and in unit tests.
+But it's not designed to work with client-side apps, and doesn't
+provide an actual server for mocked responses.
+`mockyeah` can do all of the above and more, all with the same syntax!
+
+You might also be familiar with `Polly.JS` - like `mockyeah`, it supports both client and server-side mocking.
+It's a great tool, but its design seems more oriented around
+automatically recording and replaying known requests,
+and to initiate recording requires configuration in app source code,
+which means rebuilding or redeploying your app just to be able to record.
+
 Here's an attempt to map out some of their features to help compare:
 
 |                                               | `mockyeah` | Polly.JS | nock | fetch-mock | pretender |

--- a/packages/mockyeah-docs/src/pages/Packages/mockyeah-fetch/index.mdx
+++ b/packages/mockyeah-docs/src/pages/Packages/mockyeah-fetch/index.mdx
@@ -4,6 +4,8 @@ title: \@mockyeah/fetch
 
 # `@mockyeah/fetch`
 
+If you haven't read [Getting Started - Client-Side](../../Getting-Started/Client-Side), you can start there too.
+
 `@mockyeah/fetch` can monkeypatch or be used in place of the native `fetch` API to enable some `mockyeah` features.
 This requires `fetch` API support - recommended client-side `fetch` polyfills are `whatwg-fetch` or `isomorhpic-fetch`.
 

--- a/packages/mockyeah-docs/src/pages/Packages/mockyeah-server/index.mdx
+++ b/packages/mockyeah-docs/src/pages/Packages/mockyeah-server/index.mdx
@@ -4,6 +4,8 @@ title: \@mockyeah/server
 
 # `@mockyeah/server`
 
+If you haven't read [Getting Started - Server](../../Getting-Started/Server), you can start there too.
+
 To use, simply:
 
 ```shell

--- a/packages/mockyeah-docs/src/pages/Packages/mockyeah-test-jest/index.mdx
+++ b/packages/mockyeah-docs/src/pages/Packages/mockyeah-test-jest/index.mdx
@@ -4,6 +4,8 @@ title: \@mockyeah/test-jest
 
 # `@mockyeah/test-jest`
 
+If you haven't read [Getting Started - Unit Tets](../../Getting-Started/Unit-Tests), you can start there too.
+
 If you're using the [Jest](https://jestjs.io) unit test framework, try our `@mockyeah/test-jest` package to ease setup & use.
 
 All you need to do is:

--- a/packages/mockyeah-docs/src/pages/Packages/mockyeah-test-mocha/index.mdx
+++ b/packages/mockyeah-docs/src/pages/Packages/mockyeah-test-mocha/index.mdx
@@ -4,6 +4,8 @@ title: \@mockyeah/test-mocha
 
 # `@mockyeah/test-mocha`
 
+If you haven't read [Getting Started - Unit Tets](../../Getting-Started/Unit-Tests), you can start there too.
+
 If you're using the [Mocha](https://mochajs.org) unit test framework, try our `@mockyeah/test-mocha` package to ease setup & use.
 
 All you need to do is:

--- a/packages/mockyeah-docs/src/pages/WebExtension/index.mdx
+++ b/packages/mockyeah-docs/src/pages/WebExtension/index.mdx
@@ -34,6 +34,10 @@ Here's a GIF (wait for it to load) of the extension in use at https://mockyeah-f
 
 1. Download [the `.crx` file](https://github.com/mockyeah/mockyeah/blob/master/packages/mockyeah-web-extension/mockyeah.crx?raw=true).
 
-2. In Chrome, go to `Settings` (the `⋮` icon in top-right corner) > `More Tools` > `Extensions`
+2. Extract it to a permanent location, e.g., `unzip mockyeah.crx -d mockyeah`.
 
-3. Drag & drop the `.crx` extension file onto the Extensions page.
+3. In Chrome, go to `Settings` (the `⋮` icon in top-right corner) > `More Tools` > `Extensions`
+
+4. Make sure `Developer mode` is enabled via the toggle at the top-right of the page.
+
+5. Click `Load unpacked` in the upper left and navigate to select the `mockyeah` folder.

--- a/packages/mockyeah-docs/src/pages/index.mdx
+++ b/packages/mockyeah-docs/src/pages/index.mdx
@@ -25,26 +25,12 @@ Does your app have special behavior when a service is slow to respond or a serve
 
 ## What makes `mockyeah` unique?
 
-You might be familiar with `nock` - it works great for mocking in
-server-side or other Node apps, and in unit tests.
-But it's not designed to work with client-side apps, and doesn't
-provide an actual server for mocked responses.
-`mockyeah` can do all of the above and more, all with the same syntax!
-
-You might also be familiar with `Polly.JS` - like `mockyeah`, it supports both client and server-side mocking.
-It's a great tool, but its design seems more oriented around
-automatically recording and replaying known requests,
-and to initiate recording requires configuration in app source code,
-which means rebuilding or redeploying your app just to be able to record.\
-`mockyeah` lets you create suites of mocks that you can
-opt-in to at will with a cookie. It has a powerful & expressive
-request matching API. You can easily create mocks
-from scratch or by recording. You can initiate recording
-any request on-demand from a CLI once your app is initially
-configured once upfront with `mockyeah` - set & forget!
-
+There are several tools that share some goals and use cases.
+In our view, `mockyeah` is the most universal & versatile.
 For a full comparison to other tools, see our [Compare](Compare) guide.
 
 ---
 
-Great! Next, head over our [Getting Started](Getting-Started) guide.
+Great, thanks for staying with us!
+
+Next, head over our [Getting Started](Getting-Started) guide.

--- a/packages/mockyeah-fetch/README.md
+++ b/packages/mockyeah-fetch/README.md
@@ -7,7 +7,7 @@ a powerful service mocking, recording, and playback utility.
 
 [![npm](https://img.shields.io/npm/v/@mockyeah/fetch.svg)](https://www.npmjs.com/package/@mockyeah/fetch)
 
-More at **https://mockyeah.js.org/Integration.html**.
+More at https://mockyeah.js.org/Packages/mockyeah-fetch.
 
 ## License
 

--- a/packages/mockyeah-fetch/package.json
+++ b/packages/mockyeah-fetch/package.json
@@ -14,7 +14,12 @@
     "test": "npm run type-check && npm run lint && npm run test:unit",
     "test:unit": "rm -rf src/**/*.js && jest"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/mockyeah-fetch"
+  },
+  "homepage": "https://mockyeah.js.org/Packages/mockyeah-fetch",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/mockyeah-test-jest/README.md
+++ b/packages/mockyeah-test-jest/README.md
@@ -7,6 +7,8 @@ a powerful service mocking, recording, and playback utility.
 
 [![npm](https://img.shields.io/npm/v/@mockyeah/test-jest.svg)](https://www.npmjs.com/package/@mockyeah/test-jest)
 
+More at https://mockyeah.js.org/Packages/mockyeah-test-jest.
+
 All you need to do is:
 
 ```js

--- a/packages/mockyeah-test-jest/package.json
+++ b/packages/mockyeah-test-jest/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "test": "jest"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/mockyeah-test-jest"
+  },
+  "homepage": "https://mockyeah.js.org/Packages/mockyeah-test-jest",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/mockyeah-test-mocha/README.md
+++ b/packages/mockyeah-test-mocha/README.md
@@ -7,6 +7,8 @@ a powerful service mocking, recording, and playback utility.
 
 [![npm](https://img.shields.io/npm/v/@mockyeah/test-mocha.svg)](https://www.npmjs.com/package/@mockyeah/test-mocha)
 
+More at https://mockyeah.js.org/Packages/mockyeah-test-mocha.
+
 All you need to do is:
 
 ```js

--- a/packages/mockyeah-test-mocha/package.json
+++ b/packages/mockyeah-test-mocha/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/mockyeah-test-mocha"
+  },
+  "homepage": "https://mockyeah.js.org/Packages/mockyeah-test-mocha",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/mockyeah-test-server-jest/README.md
+++ b/packages/mockyeah-test-server-jest/README.md
@@ -7,6 +7,8 @@ a powerful service mocking, recording, and playback utility.
 
 [![npm](https://img.shields.io/npm/v/@mockyeah/test-server-jest.svg)](https://www.npmjs.com/package/@mockyeah/test-server-jest)
 
+More at https://mockyeah.js.org/Packages/mockyeah-test-jest.
+
 All you need to do is:
 
 ```js

--- a/packages/mockyeah-test-server-jest/package.json
+++ b/packages/mockyeah-test-server-jest/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "test": "jest"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/mockyeah-test-server-jest"
+  },
+  "homepage": "https://mockyeah.js.org/Packages/mockyeah-test-mocha",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/mockyeah-test-server-mocha/README.md
+++ b/packages/mockyeah-test-server-mocha/README.md
@@ -7,6 +7,8 @@ a powerful service mocking, recording, and playback utility.
 
 [![npm](https://img.shields.io/npm/v/@mockyeah/test-server-mocha.svg)](https://www.npmjs.com/package/@mockyeah/test-server-mocha)
 
+More at https://mockyeah.js.org/Packages/mockyeah-test-mocha.
+
 All you need to do is:
 
 ```js

--- a/packages/mockyeah-test-server-mocha/package.json
+++ b/packages/mockyeah-test-server-mocha/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/mockyeah-test-server-mocha"
+  },
+  "homepage": "https://mockyeah.js.org/Packages/mockyeah-test-mocha",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/mockyeah-web-extension/README.md
+++ b/packages/mockyeah-web-extension/README.md
@@ -18,7 +18,7 @@ See docs at https://mockyeah.js.org/WebExtension.
 
 3. In Chrome, go to `Settings` (`⋮` icon in upper right corner) > `More Tools` > `Extensions`.
 
-4. Make sure `Developer mode` is enabled via the toggle at the top of the page.
+4. Make sure `Developer mode` is enabled via the toggle at the top-right of the page.
 
 5. Click `Load unpacked` in the upper left and navigate to select the `mockyeah-web-extension` folder.
 

--- a/packages/mockyeah/README.md
+++ b/packages/mockyeah/README.md
@@ -8,7 +8,7 @@
 [![Travis](https://img.shields.io/travis/mockyeah/mockyeah.svg)](https://travis-ci.org/mockyeah/mockyeah)
 [![Coveralls github](https://img.shields.io/coveralls/github/mockyeah/mockyeah.svg)](https://coveralls.io/github/mockyeah/mockyeah)
 
-More at **https://mockyeah.js.org**.
+More at https://mockyeah.js.org.
 
 ## License
 

--- a/packages/mockyeah/package.json
+++ b/packages/mockyeah/package.json
@@ -13,7 +13,12 @@
     "test:coverage:report": "nyc report --reporter=text-lcov | coveralls ../..",
     "lint": "eslint --max-warnings 0 ./app ./lib ./server ./test"
   },
-  "repository": "git@github.com:mockyeah/mockyeah.git",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:mockyeah/mockyeah.git",
+    "directory": "packages/mockyeah"
+  },
+  "homepage": "https://mockyeah.js.org/Packages/mockyeah-server",
   "author": "Ryan Ricard",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
Updating `package.json` adding `directory` to `repository` for each monorepo package, adding `homepage` to link to new docs site, update README URLs to new docs site. Also cross-link some package and getting started pages in the docs, and move the homepage compare blurb to compare page. Also fixing the web extension install instructions since it requires loading unpacked now.