### PR TITLE
fix: no dynamic match cookie

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -375,21 +375,8 @@ class Mockyeah {
         const name = mockSuiteNames[index];
         (mockSuiteLoaded.default || mockSuiteLoaded).forEach((mock: Mock) => {
           const [match, response] = mock;
-          const newMatch = (isPlainObject(match)
-            ? { ...(match as MatchObject) }
-            : { url: match }) as MatchObject;
-          newMatch.cookies = {
-            ...newMatch.cookies,
-            mockSuite: (value?: string): boolean =>
-              value
-                ? value
-                    .split(',')
-                    .map(s => s.trim())
-                    .includes(name)
-                : false
-          };
           dynamicMocksNormal.push(
-            this.makeMock(newMatch, response, { name, keepExisting: true }).mock
+            this.makeMock(match, response, { name, keepExisting: true }).mock
           );
         });
       });

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -365,18 +365,42 @@ class Mockyeah {
       debugError(`${logPrefix} @mockyeah/fetch couldn't parse cookies: ${error.message}`);
     }
 
-    const mockSuiteName = dynamicMockSuite || (cookies && cookies[suiteCookie]);
+    const cookieMockSuite = cookies && cookies[suiteCookie];
+    const mockSuiteName = dynamicMockSuite || cookieMockSuite;
 
     if (mockSuiteName && mockSuiteResolver) {
       const mockSuiteNames = mockSuiteName.split(',').map(s => s.trim());
       const mockSuiteLoads = mockSuiteNames.map(mockSuiteResolver);
       const mockSuiteLoadeds = await Promise.all(mockSuiteLoads);
+
       mockSuiteLoadeds.forEach((mockSuiteLoaded, index) => {
         const name = mockSuiteNames[index];
+
         (mockSuiteLoaded.default || mockSuiteLoaded).forEach((mock: Mock) => {
           const [match, response] = mock;
+
+          let newMatch: Match;
+
+          if (cookieMockSuite) {
+            newMatch = (isPlainObject(match)
+              ? { ...(match as MatchObject) }
+              : { url: match }) as MatchObject;
+            newMatch.cookies = {
+              ...newMatch.cookies,
+              mockSuite: (value?: string): boolean =>
+                value
+                  ? value
+                      .split(',')
+                      .map(s => s.trim())
+                      .includes(name)
+                  : false
+            };
+          } else {
+            newMatch = match;
+          }
+
           dynamicMocksNormal.push(
-            this.makeMock(match, response, { name, keepExisting: true }).mock
+            this.makeMock(newMatch, response, { name, keepExisting: true }).mock
           );
         });
       });


### PR DESCRIPTION
Dynamic matches are not always cookie-based - sometimes they are passed as a `dynamicMockSuite` argument to `fetch`. In those cases, we should not augment the match with the cookie value.