### PR TITLE
feat: enhance match logging, add response url

### DIFF
--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -517,6 +517,10 @@ class Mockyeah {
         realRes
       );
 
+      // Fake responses don't have URLs by default, but we'll try to add (some browsers may not allow).
+      // @ts-ignore
+      response.url = url;
+
       if (serviceWorker) {
         const responseObject: ResponseObject = {
           status: response.status,
@@ -549,9 +553,11 @@ class Mockyeah {
         url,
         {
           request: requestForHandler,
+          mock: matchingMock,
           response,
+          body: responseBody,
           json,
-          mock: matchingMock
+          headers: responseHeaders
         }
       );
 

--- a/packages/mockyeah-fetch/src/index.ts
+++ b/packages/mockyeah-fetch/src/index.ts
@@ -518,8 +518,12 @@ class Mockyeah {
       );
 
       // Fake responses don't have URLs by default, but we'll try to add (some browsers may not allow).
-      // @ts-ignore
-      response.url = url;
+      try {
+        // @ts-ignore
+        response.url = url;
+      } catch (error) {
+        // silence
+      }
 
       if (serviceWorker) {
         const responseObject: ResponseObject = {

--- a/packages/mockyeah-fetch/src/respond.ts
+++ b/packages/mockyeah-fetch/src/respond.ts
@@ -134,8 +134,8 @@ const respond = async (
   return {
     response,
     body,
-    json,
-    headers
+    headers,
+    json
   };
 };
 

--- a/packages/mockyeah-fetch/src/respond.ts
+++ b/packages/mockyeah-fetch/src/respond.ts
@@ -134,8 +134,8 @@ const respond = async (
   return {
     response,
     body,
-    headers,
-    json
+    json,
+    headers
   };
 };
 


### PR DESCRIPTION
On request match, we'll log the parsed response body and headers too, since the `Response` instance itself can obscure those behind the `Body` `ReadableStream` and `Headers` classes respectively.

Also, we'll try to attach the `url` to the `Response` object so it behaves more uniformly to a normal `Response`, even though the constructor doesn't seem to allow this.