### PR TITLE
feat: parse json from fixture/file for logs

### DIFF
--- a/packages/mockyeah-fetch/src/respond.ts
+++ b/packages/mockyeah-fetch/src/respond.ts
@@ -58,6 +58,14 @@ const respond = async (
     fixture = await handler<string>(resOpts.fixture, requestForHandler, res);
     type = type || fixture; // TODO: Use base name only to conceal file path?
     body = fixture ? await fixtureResolver(fixture) : undefined;
+
+    if (type.includes('json')) {
+      try {
+        json = JSON.parse(body);
+      } catch (error) {
+        // silence
+      }
+    }
   } else if (resOpts.filePath) {
     if (!fileResolver) {
       throw new Error('Using `filePath` in mock response options requires a `fileResolver`.');
@@ -65,6 +73,14 @@ const respond = async (
     filePath = await handler<string>(resOpts.filePath, requestForHandler, res);
     type = type || filePath; // TODO: Use base name only to conceal file path?
     body = filePath ? await fileResolver(filePath) : undefined;
+
+    if (type.includes('json')) {
+      try {
+        json = JSON.parse(body);
+      } catch (error) {
+        // silence
+      }
+    }
   } else if (resOpts.json) {
     json = await handler(resOpts.json, requestForHandler, res);
     body = JSON.stringify(json);


### PR DESCRIPTION
We now will log parsed body as `json` for a `fixture` or `filePath` mock with type of JSON (based on explicit passing `type: 'json'` or by inferring `.json` extension from file name).

Logs look like this now:
```
mockyeah:fetch:hit [mockyeah] @mockyeah/fetch matched mock for /service/exists {
  request: {
    url: '/service/exists',
    path: '/service/exists',
    query: undefined,
    method: 'get',
    headers: {
      'accept-encoding': 'gzip, deflate',
      'user-agent': 'node-superagent/3.8.3',
      connection: 'close'
    },
    body: undefined,
    cookies: undefined
  },
  mock: [
    {
      url: [Function],
      method: 'get',
      headers: undefined,
      '$meta': [Object]
    },
    { name: undefined, fixture: 'some-data.json' }
  ],
  response: Body {
    url: '/service/exists',
    status: 200,
    statusText: 'OK',
    headers: Headers { _headers: [Object] },
    ok: true,
    body: '[\n  {\n    "firstName": "Kate",\n    "lastName": "Austen"\n  },\n  {\n    ' +
      '"firstName": "John",\n    "lastName": "Locke"\n  },\n  {\n    "firstName": ' +
      '"Jack",\n    "lastName": "Shephard"\n  },\n  {\n    "firstName": ' +
      '"Charlie",\n    "lastName": "Pace"\n  },\n  {\n    "firstName": "Desmond",\n' +
      '    "lastName": "Hume"\n  },\n  {\n    "firstName": "Hugo",\n    ' +
      '"lastName": "Reyes"\n  },\n  {\n    "firstName": "James",\n    "lastName": ' +
      '"Ford"\n  }\n]\n',
    bodyUsed: false,
    size: 0,
    timeout: 0,
    _raw: [],
    _abort: false
  },
  body: '[\n  {\n    "firstName": "Kate",\n    "lastName": "Austen"\n  },\n  {\n    ' +
    '"firstName": "John",\n    "lastName": "Locke"\n  },\n  {\n    "firstName": ' +
    '"Jack",\n    "lastName": "Shephard"\n  },\n  {\n    "firstName": ' +
    '"Charlie",\n    "lastName": "Pace"\n  },\n  {\n    "firstName": "Desmond",\n' +
    '    "lastName": "Hume"\n  },\n  {\n    "firstName": "Hugo",\n    ' +
    '"lastName": "Reyes"\n  },\n  {\n    "firstName": "James",\n    "lastName": ' +
    '"Ford"\n  }\n]\n',
  json: [
    { firstName: 'Kate', lastName: 'Austen' },
    { firstName: 'John', lastName: 'Locke' },
    { firstName: 'Jack', lastName: 'Shephard' },
    { firstName: 'Charlie', lastName: 'Pace' },
    { firstName: 'Desmond', lastName: 'Hume' },
    { firstName: 'Hugo', lastName: 'Reyes' },
    { firstName: 'James', lastName: 'Ford' }
  ],
  headers: {
    'x-mockyeah-mocked': 'true',
    'x-mockyeah-fixture': 'some-data.json',
    'content-type': 'application/json'
  }
} +4ms
```
