### PR TITLE
chore(webext): use polyfill

### DIFF
--- a/packages/mockyeah-web-extension/package-lock.json
+++ b/packages/mockyeah-web-extension/package-lock.json
@@ -7134,6 +7134,11 @@
         "neo-async": "^2.5.0"
       }
     },
+    "webextension-polyfill": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.6.0.tgz",
+      "integrity": "sha512-PlYwiX8e4bNZrEeBFxbFFsLtm0SMPxJliLTGdNCA0Bq2XkWrAn2ejUd+89vZm+8BnfFB1BclJyCz3iKsm2atNg=="
+    },
     "webpack": {
       "version": "4.42.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.42.1.tgz",

--- a/packages/mockyeah-web-extension/package.json
+++ b/packages/mockyeah-web-extension/package.json
@@ -51,6 +51,7 @@
     "react-modal": "^3.11.2",
     "react-table": "^7.0.4",
     "react-tabs": "^3.1.0",
-    "react-use": "^13.27.1"
+    "react-use": "^13.27.1",
+    "webextension-polyfill": "^0.6.0"
   }
 }

--- a/packages/mockyeah-web-extension/webpack.config.ts
+++ b/packages/mockyeah-web-extension/webpack.config.ts
@@ -75,7 +75,7 @@ module.exports = [
   (env: Args = {}, argv: Args = {}) =>
     merge(defaults(env, argv), {
       entry: {
-        devtools: "./src/devtools/index.tsx"
+        devtools: ["webextension-polyfill", "./src/devtools/index.tsx"]
       },
       plugins: [
         new HtmlWebpackPlugin({
@@ -91,7 +91,7 @@ module.exports = [
   (env: Args = {}, argv: Args = {}) =>
     merge(defaults(env, argv), {
       entry: {
-        panel: "./src/panel/index.tsx"
+        panel: ["webextension-polyfill", "./src/panel/index.tsx"]
       },
       plugins: [
         new HtmlWebpackPlugin({


### PR DESCRIPTION
Starting to pull in the `webextension-polyfill` to help support Firefox and other browsers in future. We'll have to switch up some of the code to import `browser` and access the API off of that instead.